### PR TITLE
feat: 메인 페이지 UI 구현 및 페이지 레이아웃 수정

### DIFF
--- a/src/app/(private)/pos/layout.tsx
+++ b/src/app/(private)/pos/layout.tsx
@@ -6,10 +6,10 @@ export default function Layout({ children }: { children: React.ReactNode }) {
     <div className="bg-default flex flex-col min-h-screen">
       <Header storeName={'/'} />
 
-      <main className="w-[80%]  mx-auto pr-[80px] pt-8  flex-1 overflow-auto">
-        <div className="flex items-center gap-4 mb-6">
-          <BackButton />
-          <div className="flex-1">{children}</div>
+      <main className="w-[80%]  mx-auto  pt-8  flex-1 overflow-auto">
+        <BackButton />
+        <div className="flex items-center gap-4 mb-6 ">
+          <div className="flex-1 h-[calc(100vh-200px)] ">{children}</div>
         </div>
       </main>
     </div>

--- a/src/app/(private)/pos/page.tsx
+++ b/src/app/(private)/pos/page.tsx
@@ -1,7 +1,19 @@
+import ModeCard from '@/components/ModeCard';
 import React from 'react';
 
 const page = () => {
-  return <div>포스page</div>;
+  return (
+    <div className="h-full flex items-center justify-center ">
+      <div className="flex gap-6 ">
+        <ModeCard href={'/pos/tables'} content={'테이블'} />
+        <ModeCard
+          href={'/pos/products'}
+          content={'상품 관리'}
+          variant="product"
+        />
+      </div>
+    </div>
+  );
 };
 
 export default page;

--- a/src/components/ModeCard.tsx
+++ b/src/components/ModeCard.tsx
@@ -21,7 +21,7 @@ export default function ModeCard({
   return (
     <Link href={href}>
       <Card
-        className={`${variants[variant]} text-white  font-semibold cursor-pointer transition-colors h-56 w-80 rounded-2xl shadow-lg flex items-center justify-center`}
+        className={`${variants[variant]} text-white  font-semibold cursor-pointer transition-colors h-56 w-[clamp(14rem,30vw,20rem)] rounded-2xl shadow-lg flex items-center justify-center`}
       >
         <CardContent className="flex flex-col items-center justify-center gap-3 ">
           {variant === 'table' ? (


### PR DESCRIPTION
# 메인 페이지 UI 구현 및 페이지 레이아웃 수정

## 변경 사항
* 메인 페이지 UI 구현 (`/pos` 경로의 테이블/상품 관리 선택 화면)
* `ModeCard` 컴포넌트 `width` 고정값 → `clamp`로 변경 (반응형 대응)
* 페이지 레이아웃 구조 미세 조정 (children 범위 설정)

<br/>

## 작업 내용

### 배경
* POS 메인 페이지 구현(테이블/상품 관리 페이지로 진입할 수 있는 진입점)
* `ModeCard`의 `width`가 고정값이라 화면 크기에 유연하지 못한 문제가 있었고, 이를 해결하기 위해 `clamp`로 변경
* 레이아웃 구조상 children 범위가 명확하지 않아 일부 컴포넌트 배치가 어색해서 개선

<br/>

### 주요 변경 사항 및 스크린샷
1. **메인 페이지(`/pos`) UI 개발**
   * 중앙 정렬된 레이아웃 내부에 ModeCard 2개 배치 (테이블 / 상품 관리 진입)
      <img width="500" alt="스크린샷 2025-09-19 112150" src="https://github.com/user-attachments/assets/3451e106-b4bf-435e-9bfc-3a51cc629154" />

<br/>

2. **`ModeCard` 컴포넌트 CSS 코드 개선**
    * `width` 고정값 → `clamp` 적용으로 화면 크기에 따라 카드 크기가 유연하게 변동하도록 함

<br/>

3. **페이지 레이아웃 구조 수정**
   * children의 적용 범위를 명확히 설정하여 UI가 원하는 위치에 정확히 배치되도록 변경
      <img width="500" alt="페이지 레이아웃 구조 수정" src="https://github.com/user-attachments/assets/5f8185ff-74ca-415f-b662-8207024de5ff" />

<br/>

### 테스트
* 로컬 환경에서 UI 정상 동작 확인
* 카드 클릭 시 /pos/tables, /pos/products 라우팅 정상 동작 확인
* 레이아웃 구조 변경 후 다른 컴포넌트와 충돌 없음 확인

<br/>

## 참고사항
* **메인 페이지 레이아웃 구조 검토 필요**
   * 전체 페이지 레이아웃을 Header + BackButton + 여백(공백) 구조로 설계했습니다.
   * 메인 컨텐츠(children)은 빨간색 컨테이너 안에 배치되도록 해서 해당 레이아웃을 사용하는 모든 페이지에서 메인 컨텐츠가 동일한 위치에 일관되게 배치되도록 했습니다.
      <img width="500" alt="페이지 레이아웃 구조 수정" src="https://github.com/user-attachments/assets/5f8185ff-74ca-415f-b662-8207024de5ff" />

<br/>

## 체크리스트
* [x] 코드가 의도한 대로 동작하는지 확인함
* [x] 테스트를 추가/수정함
* [ ] 관련 문서/코멘트를 수정함
* [x] 셀프 리뷰 완료

