### PR TITLE
feat: 테이블 페이지 UI 구현

### DIFF
--- a/src/app/(private)/pos/tables/page.tsx
+++ b/src/app/(private)/pos/tables/page.tsx
@@ -1,3 +1,123 @@
-export default function ProductsPage() {
-  return <div>상품페이지</div>;
+import TableCard from '@/components/TableCard';
+
+interface TableCardProps {
+  tableNumber: number;
+  price: number;
+  status: 'empty' | 'using';
+  href: string;
+  menuItems?: string[];
+}
+
+// 임시 데이터
+const mockTableCards: TableCardProps[] = [
+  {
+    tableNumber: 1,
+    price: 13000,
+    status: 'empty',
+    href: '/pos/tables/1',
+  },
+  {
+    tableNumber: 2,
+    price: 25000,
+    status: 'using',
+    href: '/pos/tables/2',
+    menuItems: ['김치찌개', '삼겹살 2인분'],
+  },
+  {
+    tableNumber: 3,
+    price: 18000,
+    status: 'using',
+    href: '/pos/tables/3',
+    menuItems: ['된장찌개', '맥주'],
+  },
+  {
+    tableNumber: 4,
+    price: 0,
+    status: 'empty',
+    href: '/pos/tables/4',
+  },
+  {
+    tableNumber: 5,
+    price: 45000,
+    status: 'using',
+    href: '/pos/tables/5',
+    menuItems: ['소고기 불고기', '막국수', '콜라'],
+  },
+  {
+    tableNumber: 6,
+    price: 0,
+    status: 'empty',
+    href: '/pos/tables/6',
+  },
+  {
+    tableNumber: 7,
+    price: 12000,
+    status: 'using',
+    href: '/pos/tables/7',
+    menuItems: ['비빔밥'],
+  },
+  {
+    tableNumber: 8,
+    price: 0,
+    status: 'empty',
+    href: '/pos/tables/8',
+  },
+  {
+    tableNumber: 9,
+    price: 45000,
+    status: 'using',
+    href: '/pos/tables/5',
+    menuItems: ['소고기 불고기', '막국수', '콜라'],
+  },
+  {
+    tableNumber: 10,
+    price: 0,
+    status: 'empty',
+    href: '/pos/tables/6',
+  },
+  {
+    tableNumber: 11,
+    price: 12000,
+    status: 'using',
+    href: '/pos/tables/7',
+    menuItems: ['비빔밥'],
+  },
+  {
+    tableNumber: 12,
+    price: 0,
+    status: 'empty',
+    href: '/pos/tables/8',
+  },
+];
+
+export default function TablesPage() {
+  const filled = [...mockTableCards];
+
+  return (
+    <div className="mx-auto flex items-center justify-center h-full ">
+      <h1 className="sr-only">테이블 목록</h1>
+
+      <ul
+        className="h-[90%]
+          grid          
+          gap-x-6 gap-y-4        
+          md:gap-x-8 md:gap-y-4  
+          lg:gap-x-12 lg:gap-y-6 
+          lg:grid-cols-4 
+          md:grid-cols-3"
+        role="list"
+        aria-label="테이블 목록"
+      >
+        {filled.map((t) => (
+          <li key={t.tableNumber} className="flex">
+            <div className="w-full">
+              <div className="aspect-[4/3]">
+                <TableCard {...t} />
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/src/components/TableCard.tsx
+++ b/src/components/TableCard.tsx
@@ -24,7 +24,7 @@ export default function TableCard({
 }: TableCardProps) {
   return (
     <Link href={href}>
-      <Card className="h-40 w-48 relative">
+      <Card className="h-38 relative w-[clamp(2rem,20vw,12rem)]">
         <CardHeader className="">
           <div className="flex justify-between items-center">
             <CardTitle className="text-xl">{tableNumber}</CardTitle>


### PR DESCRIPTION
# 테이블 페이지 UI 구현

<br/>

## 변경 사항
* 테이블 페이지(`/pos/tables`) UI 구현
* 임시 목데이터(mockTableCards) 매핑
* Grid 레이아웃 적용 (태블릿, 데스크톱 반응형)

<br/>

## 작업 내용

### 배경
* 페이지 UI 단계라 백엔드 API 연동 전까지 임시 데이터로 테이블 목록을 표시함

<br/>

### 주요 변경 사항 및 스크린샷
1. **테이블 페이지에 grid 레이아웃 적용**
    * 태블릿: 3열
       <img width="400" alt="테이블 페이지 - 태블릿" src="https://github.com/user-attachments/assets/2a4a7fe0-55ef-43e7-956b-95ffb4c59177" />

    * 데스크톱: 4열
       <img width="500" alt="테이블 페이지" src="https://github.com/user-attachments/assets/ebbdfb68-de03-414d-989a-4b7bdc8077a2" />

2. **TableCard 컴포넌트**
   * 유연한 그리드 배치를 위해 w-고정값을 clamp() 사용으로 수정, height 값 수정

<br/>

### 테스트
* 로컬 환경에서 태블릿, 데스크톱 뷰포트 확인
* 카드가 항상 4:3 비율 유지하는지 확인
* 12개의 임시 데이터가 정상적으로 렌더링되는지 확인
* 페이지 스크롤 및 반응형 전환 시 깨짐 현상 없는지 확인

<br/>

## 참고사항
* 현재는 mock 데이터 기반이므로 API 연동 시 데이터 소스 교체 예정
* 페이지네이션을 도입할 경우, grid 레이아웃 구조는 그대로 유지하고 페이지 단위로 데이터를 나눠서 렌더링 예정
* 반응형 레이아웃은 1차 MVP에서 고려 요건이 아니기 때문에 최대 태블릿까지만 사용할 수 있도록 함

<br/>

## 체크리스트
* [x] 코드가 의도한 대로 동작하는지 확인함
* [ ] 테스트를 추가/수정함
* [ ] 관련 문서/코멘트를 수정함
* [x] 셀프 리뷰 완료

