### PR TITLE
feat: 회원가입 페이지 레이아웃 구현

### DIFF
--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -1,0 +1,16 @@
+import Header from '@/components/Header';
+
+export default function PosMenuLayout({
+  children,
+}: {
+  children: React.ReactNode;
+  modal: React.ReactNode;
+}) {
+  return (
+    <>
+      <div className="bg-default flex flex-col min-h-screen">
+        <main>{children}</main>
+      </div>
+    </>
+  );
+}

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,7 +1,50 @@
 import React from 'react';
+import Link from 'next/link';
+import Button from '@/components/Button';
+
+const signupCategory = [
+  { type: 'text', placeholder: '아이디' },
+  { type: 'password', placeholder: '비밀번호' },
+  { type: 'number', placeholder: '핸드폰' },
+  { type: 'text', placeholder: '매장명' },
+  { type: 'number', placeholder: '매장 테이블 수' },
+];
 
 const singnup = () => {
-  return <div>singnup</div>;
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-gray-50">
+      <div className="w-full max-w-md bg-white shadow-lg rounded-2xl p-8">
+        <div className="flex flex-row items-center mb-6">
+          <h2 className="text-2xl font-bold text-center">회원가입</h2>
+        </div>
+        {/* 회원가입 폼 */}
+        <form className="space-y-4">
+          {signupCategory.map((field, idx) => (
+            <div key={idx}>
+              <input
+                type={field.type}
+                placeholder={field.placeholder}
+                className="w-full border rounded-lg px-4 py-3 focus:ring-2 focus:ring-blue-500 outline-none"
+              />
+            </div>
+          ))}
+
+          {/* 회원가입 버튼 */}
+          <Button variant="default" className="w-full h-12 mt-4">
+            회원가입
+          </Button>
+        </form>
+
+        {/* 하단 링크 */}
+        <p className="mt-6 text-sm text-gray-600 text-center">
+          이미 계정이 있으신가요?{' '}
+          <Link href="/" className="text-blue-500 hover:underline">
+            로그인하기
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
 };
 
 export default singnup;

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import Link from 'next/link';
 import Button from '@/components/Button';
@@ -5,9 +6,14 @@ import Button from '@/components/Button';
 const signupCategory = [
   { type: 'text', placeholder: '아이디' },
   { type: 'password', placeholder: '비밀번호' },
-  { type: 'number', placeholder: '핸드폰' },
+  {
+    type: 'text',
+    placeholder: '핸드폰( -는 빼고 입력해주세요 )',
+    inputMode: 'numeric',
+    maxLength: 11,
+  },
   { type: 'text', placeholder: '매장명' },
-  { type: 'number', placeholder: '매장 테이블 수' },
+  { type: 'number', placeholder: '매장 테이블 수', min: 0 },
 ];
 
 const singnup = () => {
@@ -22,20 +28,30 @@ const singnup = () => {
           {signupCategory.map((field, idx) => (
             <div key={idx}>
               <input
-                type={field.type}
-                placeholder={field.placeholder}
-                className="w-full border rounded-lg px-4 py-3 focus:ring-2 focus:ring-blue-500 outline-none"
+                {...(field as React.InputHTMLAttributes<HTMLInputElement>)}
+                className="w-full rounded-lg border px-4 py-3 outline-none focus:ring-2 focus:ring-blue-500"
+                onWheel={
+                  field.type === 'number'
+                    ? (e) => (e.currentTarget as HTMLInputElement).blur()
+                    : undefined
+                }
+                onKeyDown={
+                  field.type === 'number'
+                    ? (e) => {
+                        if (['e', 'E', '+', '-'].includes(e.key))
+                          e.preventDefault();
+                      }
+                    : undefined
+                }
               />
             </div>
           ))}
 
-          {/* 회원가입 버튼 */}
           <Button variant="default" className="w-full h-12 mt-4">
             회원가입
           </Button>
         </form>
 
-        {/* 하단 링크 */}
         <p className="mt-6 text-sm text-gray-600 text-center">
           이미 계정이 있으신가요?{' '}
           <Link href="/" className="text-blue-500 hover:underline">


### PR DESCRIPTION
# PR 템플릿 양식

## 변경 사항

- 작업한 주요 내용을 요약하여 적습니다.
- 기능 추가, 버그 수정, 리팩토링 등 어떤 작업을 했는지 나열합니다.

## 작업 내용
- 회원가입 페이지 UI 구현
- 배경은 다른 페이지들과 통일하게 `bg-default` 적용
- 테이블수를 `<input type="number" />` 로 하니 - 까지 내려가버려 최소 `min=0` 적용

### 배경

- 로그인 페이지에서 넘어갈 수 있는 회원가입페이지 레이아웃 입니다.

### 주요 변경 사항 및 스크린샷

<img width="1913" height="927" alt="image" src="https://github.com/user-attachments/assets/298dd00a-66a4-4e3d-bfff-3f5fdc551d83" />

- 피그마에서는 회원가입 왼쪽에 `BackButton` 아이콘을 추가하기로 했으나 미관상 이상하다고 생각하고 아래에 로그인하기 버튼을 추가 하였습니다.

### 테스트

- 로그인하기 클릭시 `Link` 정상적으로 작동
- 안깨짐 현상 확인

## 참고사항

- `disabled` 및 api 500 에러시 나올 메시지 미구현 (API 연동하면서 부착 할 예정)

## 체크리스트

- [x] 코드가 의도한 대로 동작하는지 확인함
- [x] 테스트를 추가/수정함
- [ ] 관련 문서/코멘트를 수정함
- [x] 셀프 리뷰 완료
