### PR TITLE
fix: 기획 변경에 따른 UI 수정 및 ConfirmModal 모달 컴포넌트 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "servenow",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.2.3",
@@ -982,6 +983,34 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
       "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",

--- a/src/app/(private)/pos/(shell-layout)/tables/@modal/(.)setup/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/tables/@modal/(.)setup/page.tsx
@@ -9,7 +9,12 @@ export default function TableSetupModal() {
     <>
       <ModalShell title={'테이블 설정'} size="sm">
         <div>
-          <p className="text-lg">테이블 개수</p>
+          <div>
+            <p className="text-lg">테이블 개수</p>
+            <p className="text-xs text-text-error">
+              모든 테이블이 빈 상태일 때 수정 가능합니다.
+            </p>
+          </div>
           <div className="flex justify-center">
             <div className="flex flex-col gap-4  w-72">
               <Input type={'text'} className="w-full h-11" />

--- a/src/app/(private)/pos/(shell-layout)/tables/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/tables/page.tsx
@@ -2,8 +2,8 @@ import TableCard from '@/components/TableCard';
 
 interface TableCardProps {
   tableNumber: number;
-  price: number;
-  status: 'empty' | 'using';
+  price?: number;
+  status: 'EMPTY' | 'ORDERED' | 'SERVED';
   href: string;
   menuItems?: string[];
 }
@@ -12,81 +12,75 @@ interface TableCardProps {
 const mockTableCards: TableCardProps[] = [
   {
     tableNumber: 1,
-    price: 13000,
-    status: 'empty',
+    status: 'EMPTY',
     href: '/pos/tables/1',
   },
   {
     tableNumber: 2,
     price: 25000,
-    status: 'using',
+    status: 'ORDERED',
     href: '/pos/tables/2',
     menuItems: ['김치찌개', '삼겹살 2인분'],
   },
   {
     tableNumber: 3,
     price: 18000,
-    status: 'using',
+    status: 'SERVED',
     href: '/pos/tables/3',
     menuItems: ['된장찌개', '맥주'],
   },
   {
     tableNumber: 4,
-    price: 0,
-    status: 'empty',
+    status: 'EMPTY',
     href: '/pos/tables/4',
   },
   {
     tableNumber: 5,
     price: 45000,
-    status: 'using',
+    status: 'ORDERED',
     href: '/pos/tables/5',
     menuItems: ['소고기 불고기', '막국수', '콜라'],
   },
   {
     tableNumber: 6,
-    price: 0,
-    status: 'empty',
+    status: 'EMPTY',
     href: '/pos/tables/6',
   },
   {
     tableNumber: 7,
     price: 12000,
-    status: 'using',
+    status: 'SERVED',
     href: '/pos/tables/7',
     menuItems: ['비빔밥'],
   },
   {
     tableNumber: 8,
-    price: 0,
-    status: 'empty',
+    status: 'EMPTY',
     href: '/pos/tables/8',
   },
   {
     tableNumber: 9,
     price: 45000,
-    status: 'using',
-    href: '/pos/tables/5',
+    status: 'ORDERED',
+    href: '/pos/tables/9',
     menuItems: ['소고기 불고기', '막국수', '콜라'],
   },
   {
     tableNumber: 10,
-    price: 0,
-    status: 'empty',
-    href: '/pos/tables/6',
+    status: 'EMPTY',
+    href: '/pos/tables/10',
   },
   {
     tableNumber: 11,
     price: 12000,
-    status: 'using',
-    href: '/pos/tables/7',
+    status: 'SERVED',
+    href: '/pos/tables/11',
     menuItems: ['비빔밥'],
   },
   {
     tableNumber: 12,
-    price: 0,
-    status: 'empty',
-    href: '/pos/tables/8',
+    status: 'EMPTY',
+    href: '/pos/tables/12',
   },
 ];
 

--- a/src/app/(private)/pos/tables/[tableId]/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/page.tsx
@@ -4,10 +4,9 @@ import { Trash2, Plus, Minus } from 'lucide-react';
 import MenuButton from '@/components/MenuButton';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
-
-interface PosMenuPageProps {
-  params: { tableId: string };
-}
+import { useState } from 'react';
+import { useParams } from 'next/navigation';
+import ConfirmModal from '@/components/ConfirmModal';
 
 // 임시 데이터 - 카테고리
 const categories = ['즐겨찾는 메뉴', '한식', '분식', '양식'];
@@ -33,8 +32,27 @@ const ORDER_ITEMS = [
   { id: 8, name: '돈까스', price: 13000, quantity: 1 },
 ];
 
-export default function PosMenuPage({ params }: PosMenuPageProps) {
-  const { tableId } = params;
+type ModalType = 'trash' | 'cancel';
+
+const MODAL = {
+  trash: {
+    title: '담아둔 메뉴를 모두 삭제할까요?',
+    description: '주문 내역에 담아둔 항목이 모두 지워집니다.',
+    confirmText: '전체 삭제',
+  },
+  cancel: {
+    title: '주문을 취소하시겠습니까?',
+    description: '기존 주문 내역이 모두 취소됩니다.',
+    confirmText: '주문 취소',
+  },
+} as const;
+
+export default function PosMenuPage() {
+  const { tableId } = useParams<{ tableId: string }>();
+  const [modal, setModal] = useState<ModalType | null>(null);
+
+  const open = (type: ModalType) => setModal(type);
+  const close = () => setModal(null);
 
   return (
     <div className="flex h-[89vh] bg-default">
@@ -90,14 +108,20 @@ export default function PosMenuPage({ params }: PosMenuPageProps) {
                 type="checkbox"
                 className="h-5 w-5 cursor-pointer rounded-md border border-gray-300 bg-gray-300"
               />
-              <Trash2 className="w-5 h-5 text-gray-400 cursor-pointer hover:text-gray-600" />
+              <Button
+                className="w-7 h-7 text-gray-400 cursor-pointer hover:text-gray-600"
+                variant={'ghost'}
+                onClick={() => open('trash')}
+              >
+                <Trash2 />
+              </Button>
             </div>
           </div>
         </div>
 
         {/* 주문 내역 - 스크롤 영역 */}
         <div className="flex-1">
-          <div className="h-[450px] overflow-y-auto scrollbar-hide">
+          <div className="h-[400px] overflow-y-auto scrollbar-hide">
             <div className="p-4 space-y-3">
               {ORDER_ITEMS.map((item) => (
                 <div
@@ -132,6 +156,18 @@ export default function PosMenuPage({ params }: PosMenuPageProps) {
 
         {/* 하단 고정 버튼 영역 */}
         <div className="p-4 border-t space-y-3 flex-shrink-0">
+          <div className="flex justify-end">
+            <div className="w-28">
+              <Button
+                variant={'link'}
+                className="w-full justify-end underline text-sm hover:text-gray-900 text-gray-400 pr-2"
+                onClick={() => open('cancel')}
+              >
+                <span>주문 취소</span>
+              </Button>
+            </div>
+          </div>
+
           <Button variant={'default'} className="w-full">
             <span className="bg-white text-blue-500 rounded-full w-6 h-6 flex items-center justify-center text-sm font-bold">
               {'1'}
@@ -146,6 +182,16 @@ export default function PosMenuPage({ params }: PosMenuPageProps) {
           </Button>
         </div>
       </div>
+      {modal && (
+        <ConfirmModal
+          open={true}
+          onOpenChange={(o) => !o && close()}
+          {...MODAL[modal]}
+          onConfirm={() => {
+            close();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogCancel,
+  AlertDialogAction,
+  AlertDialogHeader,
+  AlertDialogFooter,
+} from '@/components/ui/alert-dialog';
+
+type ConfirmModalProps = {
+  open: boolean;
+  title: string;
+  description?: string;
+  confirmText: string;
+  cancelText?: string;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void | Promise<void>;
+};
+
+export default function ConfirmModal({
+  open,
+  title,
+  description,
+  confirmText,
+  cancelText = '취소',
+  onOpenChange,
+  onConfirm,
+}: ConfirmModalProps) {
+  const handleConfirm = async () => {
+    await onConfirm(); // 이후 API 연결
+    onOpenChange(false); // 명시적으로 닫기
+  };
+
+  return (
+    <AlertDialog open={open}>
+      <AlertDialogContent className="sm:max-w-[420px]">
+        <AlertDialogHeader>
+          <AlertDialogTitle className="text-center">{title}</AlertDialogTitle>
+          {description && (
+            <AlertDialogDescription className="text-center">
+              {description}
+            </AlertDialogDescription>
+          )}
+        </AlertDialogHeader>
+
+        <AlertDialogFooter className="sm:justify-center gap-2">
+          <AlertDialogCancel
+            onClick={() => onOpenChange(false)}
+            className="sm:w-28"
+          >
+            {cancelText}
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            className="sm:w-28 bg-red-600 hover:bg-red-700"
+          >
+            {confirmText}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/TableCard.tsx
+++ b/src/components/TableCard.tsx
@@ -9,8 +9,8 @@ import {
 
 interface TableCardProps {
   tableNumber: number;
-  price: number;
-  status: 'using' | 'empty';
+  price?: number;
+  status: 'EMPTY' | 'ORDERED' | 'SERVED';
   href: string;
   menuItems?: string[];
 }
@@ -22,6 +22,12 @@ export default function TableCard({
   href,
   menuItems,
 }: TableCardProps) {
+  const BADGE_TABLE: Record<'EMPTY' | 'ORDERED' | 'SERVED', string> = {
+    EMPTY: 'bg-gray-300 text-gray-800',
+    ORDERED: 'bg-amber-500 ',
+    SERVED: 'bg-green-600',
+  };
+
   return (
     <Link href={href}>
       <Card className="h-38 relative w-[clamp(2rem,20vw,12rem)]">
@@ -29,9 +35,7 @@ export default function TableCard({
           <div className="flex justify-between items-center">
             <CardTitle className="text-xl">{tableNumber}</CardTitle>
             <span
-              className={`px-2 py-1 rounded text-xs ${
-                status === 'empty' ? 'bg-gray-300' : 'bg-green text-white'
-              }`}
+              className={`px-2 py-1 rounded text-[10px] text-white ${BADGE_TABLE[status]}`}
             >
               {status}
             </span>
@@ -51,10 +55,10 @@ export default function TableCard({
           )}
         </CardContent>
 
-        {status === 'using' && (
+        {status !== 'EMPTY' && (
           <CardFooter className="absolute bottom-4 right-5 p-0">
             <p className="truncate font-semibold text-lg">
-              {price.toLocaleString()}
+              {price?.toLocaleString()}
             </p>
           </CardFooter>
         )}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}


### PR DESCRIPTION
# 기획 변경에 따른 UI 수정 및 ConfirmModal 모달 컴포넌트 추가

## 변경 사항
* 기획 변경에 따라 테이블 페이지 UI 수정 (상태: ORDERED | SERVED)
* 테이블 Setup 모달에 조건별 경고 문구 추가
* 공통 취소/삭제 확인 모달(ConfirmModal) 컴포넌트 구현
* 포스 메뉴 페이지에 ‘주문 취소’ 버튼 추가
* 휴지통 및 주문 취소 액션 시 컨펌 모달 연동

<br/>

## 작업 내용

### 배경
* 기획이 변경되면서 테이블 상태 UI와 관련 기능이 수정 필요
* 테이블 개수 변경 시 특정 조건에 따라 사용자에게 경고 문구 노출하도록 수정
* 주문 취소 및 휴지통 액션에서 사용자 확인 절차가 요구되어 컨펌 모달 추가

<br/>

### 주요 변경 사항 및 스크린샷

1. **테이블 상태 UI 개편**
   * `status` prop에 `'ORDERED' | 'SERVED'` 추가(`'EMPTY' | 'ORDERED' | 'SERVED'`)
   * 관련 mock 데이터 및 UI 업데이트 반영
      <img width="600" alt="테이블 페이지" src="https://github.com/user-attachments/assets/34a507d1-b79e-430e-8760-995a3f30938b" />

<br/>

2. **테이블 Setup 모달 – 경고 문구 추가**
   * 테이블 개수 변경 시 변경 조건 경고 문구 추가
      <img width="600" alt="테이블 setup 모달" src="https://github.com/user-attachments/assets/0adf6953-6de7-4f2e-a798-6e58e2572dfa" />

<br/>

3. **공통 ConfirmModal 컴포넌트 생성**
   * `AlertDialog` 기반으로 구현
   * Props: `title`, `description`, `confirmText`, `cancelText`, `onConfirm` 등

<br/>

4. **포스 메뉴 페이지 – 주문 취소 버튼 추가**
   * 주문 취소 버튼 클릭 시 컨펌 모달 연동
      <img width="600" alt="주문 취소 모달 - 주문 취소" src="https://github.com/user-attachments/assets/e42a0304-7684-4ad6-b993-c5030e71bfdf" />

<br/>

5. **포스 메뉴 페이지 – 휴지통 클릭 시 컨펌 모달 연동**
   <img width="600" alt="휴지통 모달 - 주문 내역 삭제" src="https://github.com/user-attachments/assets/10658da5-e25f-4aea-a5a4-fccf5739105a" />

<br/>

## 테스트
* 로컬에서 UI 변경 사항 정상 동작 확인
* 주문 취소/삭제 시 컨펌 모달 정상 노출 및 닫기 동작 확인

<br/>

## 체크리스트
* [x] 코드가 의도한 대로 동작하는지 확인함
* [x] 테스트를 추가/수정함
* [x] 관련 문서/코멘트를 수정함
* [x] 셀프 리뷰 완료

