### PR TITLE
feat: 테이블 페이지 조회 및 페이지네이션 기능 구현

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
+import pluginQuery from "@tanstack/eslint-plugin-query";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -11,6 +12,7 @@ const compat = new FlatCompat({
 
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...pluginQuery.configs["flat/recommended"],
   {
     ignores: [
       "node_modules/**",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,14 @@
 import type { NextConfig } from 'next';
 
-const nextConfig: NextConfig = {};
+const nextConfig: NextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: 'http://3.39.230.117:8080/api/:path*',
+      },
+    ];
+  },
+};
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.2.3",
         "@tanstack/react-query": "^5.87.4",
+        "@tanstack/react-query-devtools": "^5.90.2",
         "axios": "^1.12.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1660,9 +1661,19 @@
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.87.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.87.4.tgz",
-      "integrity": "sha512-uNsg6zMxraEPDVO2Bn+F3/ctHi+Zsk+MMpcN8h6P7ozqD088F6mFY5TfGM7zuyIrL7HKpDyu6QHfLWiDxh3cuw==",
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.2.tgz",
+      "integrity": "sha512-k/TcR3YalnzibscALLwxeiLUub6jN5EDLwKDiO7q5f4ICEoptJ+n9+7vcEFy5/x/i6Q+Lb/tXrsKCggf5uQJXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.90.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.90.1.tgz",
+      "integrity": "sha512-GtINOPjPUH0OegJExZ70UahT9ykmAhmtNVcmtdnOZbxLwT7R5OmRztR5Ahe3/Cu7LArEmR6/588tAycuaWb1xQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1670,18 +1681,35 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.87.4",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.87.4.tgz",
-      "integrity": "sha512-T5GT/1ZaNsUXf5I3RhcYuT17I4CPlbZgyLxc/ZGv7ciS6esytlbjb3DgUFO6c8JWYMDpdjSWInyGZUErgzqhcA==",
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
+      "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.87.4"
+        "@tanstack/query-core": "5.90.2"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.90.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.90.2.tgz",
+      "integrity": "sha512-vAXJzZuBXtCQtrY3F/yUNJCV4obT/A/n81kb3+YqLbro5Z2+phdAbceO+deU3ywPw8B42oyJlp4FhO0SoivDFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.90.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.2",
         "react": "^18 || ^19"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "@eslint/eslintrc": "^3",
         "@eslint/js": "^9.35.0",
         "@tailwindcss/postcss": "^4.1.13",
+        "@tanstack/eslint-plugin-query": "^5.90.1",
         "@types/node": "^20.19.15",
         "@types/react": "^19.1.13",
         "@types/react-dom": "^19",
@@ -1658,6 +1659,23 @@
         "@tailwindcss/oxide": "4.1.13",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.13"
+      }
+    },
+    "node_modules/@tanstack/eslint-plugin-query": {
+      "version": "5.90.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.90.1.tgz",
+      "integrity": "sha512-Ki4hl+8ZtnMFZ3amZbQl6sSMUq6L8oSJ14vmi3j5t1/SqXclL5SI/1kcuH36iIk05B/bN5pEOS1PTO3Ut/FbVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^8.44.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0"
       }
     },
     "node_modules/@tanstack/query-core": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.87.4",
+    "@tanstack/react-query-devtools": "^5.90.2",
     "axios": "^1.12.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@eslint/eslintrc": "^3",
     "@eslint/js": "^9.35.0",
     "@tailwindcss/postcss": "^4.1.13",
+    "@tanstack/eslint-plugin-query": "^5.90.1",
     "@types/node": "^20.19.15",
     "@types/react": "^19.1.13",
     "@types/react-dom": "^19",

--- a/src/app/(private)/pos/(shell-layout)/tables/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/tables/page.tsx
@@ -19,12 +19,8 @@ export default function TablesPage() {
   const [noticeText, setNoticeText] = useState<string | null>(null);
 
   useEffect(() => {
-    let aborted = false;
-
     getTables(page, PAGE_SIZE)
       .then((res) => {
-        if (aborted) return;
-
         setData(res);
         setCards(
           res.content.map((item) => ({
@@ -43,8 +39,6 @@ export default function TablesPage() {
         console.log('[MAP] cards:', cards);
       })
       .catch((err) => {
-        if (aborted) return;
-
         const title = err?.response?.data?.title as string | undefined;
         setNoticeText(title ?? '요청을 처리하지 못했습니다.');
 
@@ -54,17 +48,12 @@ export default function TablesPage() {
           err?.response?.data,
         );
       });
-
-    return () => {
-      aborted = true;
-    };
   }, [page]);
 
   const pageNumber = data?.number ?? page;
-  const totalPages = data?.totalPages ?? 1;
 
-  const isFirst = pageNumber <= 0;
-  const isLast = pageNumber >= totalPages - 1;
+  const isFirst = data?.first ?? true;
+  const isLast = data?.last ?? true;
 
   const showPager = (data?.totalPages ?? 0) > 1;
 
@@ -85,6 +74,12 @@ export default function TablesPage() {
       {noticeText && (
         <div className="mb-4 rounded-md border border-red-300 bg-red-50 px-3 py-2 text-md text-red-800">
           {noticeText}
+        </div>
+      )}
+
+      {data?.empty && (
+        <div className="text-sm text-muted-foreground my-4">
+          등록된 테이블이 없습니다.
         </div>
       )}
 

--- a/src/app/(private)/pos/(shell-layout)/tables/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/tables/page.tsx
@@ -48,7 +48,9 @@ export default function TablesPage() {
 
       {showPager && (
         <button
-          className="rounded px-3 py-1 disabled:opacity-50 mr-8 cursor-pointer"
+          type="button"
+          aria-label="이전 페이지"
+          className="rounded px-3 py-1 disabled:opacity-50 mr-8 cursor-pointer disabled:cursor-not-allowed"
           onClick={goPrev}
           disabled={isFirst}
         >
@@ -80,7 +82,9 @@ export default function TablesPage() {
 
       {showPager && (
         <button
-          className="rounded px-3 py-1 ml-8 disabled:opacity-50 cursor-pointer"
+          type="button"
+          aria-label="다음 페이지"
+          className="rounded px-3 py-1 ml-8 disabled:opacity-50 cursor-pointer disabled:cursor-not-allowed"
           onClick={goNext}
           disabled={isLast}
         >

--- a/src/app/(private)/pos/(shell-layout)/tables/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/tables/page.tsx
@@ -1,54 +1,17 @@
 'use client';
 
-import TableCard, { TableCardProps } from '@/components/TableCard';
-import { getTables, PAGE_SIZE, TablesResponse } from '@/app/api/tables';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useState, useEffect } from 'react';
+import TableCard from '@/components/TableCard';
+import useTables from '@/hooks/useTables';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 
 export default function TablesPage() {
-  // 현재 URL에서 페이지 번호 읽기
+  const router = useRouter();
+
   const sp = useSearchParams();
   const page = Math.max(0, Number(sp.get('page') ?? 0));
 
-  const router = useRouter();
-
-  // 데이터 및 에러 상태
-  const [data, setData] = useState<TablesResponse | null>(null);
-  const [cards, setCards] = useState<TableCardProps[]>([]);
-  const [noticeText, setNoticeText] = useState<string | null>(null);
-
-  useEffect(() => {
-    getTables(page, PAGE_SIZE)
-      .then((res) => {
-        setData(res);
-        setCards(
-          res.content.map((item) => ({
-            tableNumber: item.restaurantTableNumber,
-            status:
-              item.status === 'EMPTY'
-                ? 'EMPTY'
-                : item.status === 'SERVED'
-                ? 'SERVED'
-                : 'ORDERED',
-            href: `/pos/tables/${item.restaurantTableNumber}`,
-          })),
-        );
-
-        console.log('[API] tables raw:', res);
-        console.log('[MAP] cards:', cards);
-      })
-      .catch((err) => {
-        const title = err?.response?.data?.title as string | undefined;
-        setNoticeText(title ?? '요청을 처리하지 못했습니다.');
-
-        console.error(
-          '[tables:error]',
-          err?.response?.status,
-          err?.response?.data,
-        );
-      });
-  }, [page]);
+  const { data, cards, noticeText } = useTables(page);
 
   const pageNumber = data?.number ?? page;
 
@@ -78,7 +41,7 @@ export default function TablesPage() {
       )}
 
       {data?.empty && (
-        <div className="text-sm text-muted-foreground my-4">
+        <div className="text-lg text-muted-foreground my-4">
           등록된 테이블이 없습니다.
         </div>
       )}

--- a/src/app/api/tables.ts
+++ b/src/app/api/tables.ts
@@ -1,0 +1,24 @@
+export type TablesPage = {
+  content: {
+    id: number;
+    restaurantTableNumber: number;
+    status: string;
+  }[];
+  number: number;
+  totalPages: number;
+  totalElements: number;
+  size: number;
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+};
+
+export async function getTables({ page, size = 12 }): Promise<TablesPage> {
+  const { data } = instance.get('/api/tales', {
+    params: {
+      page,
+      size,
+    },
+  });
+  return data;
+}

--- a/src/app/api/tables.ts
+++ b/src/app/api/tables.ts
@@ -1,4 +1,6 @@
-export type TablesPage = {
+import { instance } from '@/lib/axios';
+
+export type TablesResponse = {
   content: {
     id: number;
     restaurantTableNumber: number;
@@ -13,12 +15,14 @@ export type TablesPage = {
   empty: boolean;
 };
 
-export async function getTables({ page, size = 12 }): Promise<TablesPage> {
-  const { data } = instance.get('/api/tales', {
-    params: {
-      page,
-      size,
-    },
+export const PAGE_SIZE = 12;
+
+export async function getTables(
+  page: number,
+  size = PAGE_SIZE,
+): Promise<TablesResponse> {
+  const { data } = await instance.get('/tables', {
+    params: { page, size },
   });
   return data;
 }

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,12 +1,16 @@
 'use client';
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { ReactNode, useState } from 'react';
 
 export default function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(() => new QueryClient());
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   );
 }

--- a/src/components/TableCard.tsx
+++ b/src/components/TableCard.tsx
@@ -7,7 +7,7 @@ import {
   CardFooter,
 } from './ui/card';
 
-interface TableCardProps {
+export interface TableCardProps {
   tableNumber: number;
   price?: number;
   status: 'EMPTY' | 'ORDERED' | 'SERVED';

--- a/src/hooks/useTables.ts
+++ b/src/hooks/useTables.ts
@@ -1,43 +1,29 @@
 import { getTables, PAGE_SIZE, TablesResponse } from '@/app/api/tables';
 import { TableCardProps } from '@/components/TableCard';
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 
 export default function useTables(page: number) {
-  const [data, setData] = useState<TablesResponse | null>(null);
-  const [cards, setCards] = useState<TableCardProps[]>([]);
-  const [noticeText, setNoticeText] = useState<string | null>(null);
+  const query = useQuery<TablesResponse>({
+    queryKey: ['tables', page],
+    queryFn: () => getTables(page, PAGE_SIZE),
+    staleTime: 1000 * 60,
+  });
 
-  useEffect(() => {
-    getTables(page, PAGE_SIZE)
-      .then((res) => {
-        setData(res);
-        setCards(
-          res.content.map((item) => ({
-            tableNumber: item.restaurantTableNumber,
-            status:
-              item.status === 'EMPTY'
-                ? 'EMPTY'
-                : item.status === 'SERVED'
-                ? 'SERVED'
-                : 'ORDERED',
-            href: `/pos/tables/${item.restaurantTableNumber}`,
-          })),
-        );
+  const cards: TableCardProps[] =
+    query.data?.content.map((item) => ({
+      tableNumber: item.restaurantTableNumber,
+      status:
+        item.status === 'EMPTY'
+          ? 'EMPTY'
+          : item.status === 'SERVED'
+          ? 'SERVED'
+          : 'ORDERED',
+      href: `/pos/tables/${item.restaurantTableNumber}`,
+    })) ?? [];
 
-        console.log('[API] tables raw:', res);
-        console.log('[MAP] cards:', cards);
-      })
-      .catch((err) => {
-        const title = err?.response?.data?.title as string | undefined;
-        setNoticeText(title ?? '요청을 처리하지 못했습니다.');
-
-        console.error(
-          '[tables:error]',
-          err?.response?.status,
-          err?.response?.data,
-        );
-      });
-  }, [page]);
-
-  return { data, cards, noticeText };
+  return {
+    data: query.data,
+    cards,
+    noticeText: query.error ? '요청을 처리하지 못했습니다.' : null,
+  };
 }

--- a/src/hooks/useTables.ts
+++ b/src/hooks/useTables.ts
@@ -1,0 +1,43 @@
+import { getTables, PAGE_SIZE, TablesResponse } from '@/app/api/tables';
+import { TableCardProps } from '@/components/TableCard';
+import { useEffect, useState } from 'react';
+
+export default function useTables(page: number) {
+  const [data, setData] = useState<TablesResponse | null>(null);
+  const [cards, setCards] = useState<TableCardProps[]>([]);
+  const [noticeText, setNoticeText] = useState<string | null>(null);
+
+  useEffect(() => {
+    getTables(page, PAGE_SIZE)
+      .then((res) => {
+        setData(res);
+        setCards(
+          res.content.map((item) => ({
+            tableNumber: item.restaurantTableNumber,
+            status:
+              item.status === 'EMPTY'
+                ? 'EMPTY'
+                : item.status === 'SERVED'
+                ? 'SERVED'
+                : 'ORDERED',
+            href: `/pos/tables/${item.restaurantTableNumber}`,
+          })),
+        );
+
+        console.log('[API] tables raw:', res);
+        console.log('[MAP] cards:', cards);
+      })
+      .catch((err) => {
+        const title = err?.response?.data?.title as string | undefined;
+        setNoticeText(title ?? '요청을 처리하지 못했습니다.');
+
+        console.error(
+          '[tables:error]',
+          err?.response?.status,
+          err?.response?.data,
+        );
+      });
+  }, [page]);
+
+  return { data, cards, noticeText };
+}

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,9 +1,7 @@
 import axios from 'axios';
 
-const baseURL = process.env.API_URL;
-
 export const instance = axios.create({
-  baseURL,
+  baseURL: '/api',
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
# 테이블 페이지 조회 및 페이지네이션 기능 구현

## 변경 사항
* 테이블 페이지 전체 조회 API 연동 및 페이지네이션 로직 추가
* axios 인스턴스 설정 수정
   * 기존: `process.env.API_URL` 기반
   * 변경: `baseURL: '/api'` 로 고정 (개발 환경 프록시 활용)
* Next.js rewrites 설정 추가
    * `/api/:path*` → `http://3.39.230.117:8080/api/:path*` 로 프록시 동작하도록 설정
* react-query-devtools 및 react-query eslint 설치, 추가
* 기존 테이블 api 호출 로직을 React-query를 사용하는 방식으로 리팩토링

<br/>

## 작업 내용

### 배경
* 테이블 페이지 api 연결 및 페이지네이션 기능 개발
* 로컬 개발 시 CORS 문제가 발생 → Next.js `rewrites` 기능을 추가해 클라이언트 코드에서는 `/api`로 고정하고, 실제 요청은 서버 프록시를 통해 백엔드로 전달되도록 변경

<br/>

### 주요 변경 사항 및 스크린샷

1. **`getTables` API 함수 작성: 페이지/사이즈 기반 조회**

<br/>

2. **테이블 페이지**
    * API 연동 및 페이지네이션 구현
    * 에러/빈 상태 UI 처리
    * 페이지네이션 버튼 UI 구현
    * API 호출 및 상태 관리 로직 `useTables` 훅으로 분리
       <img width="600" alt="테이블 페이지 - 페이지네이션" src="https://github.com/user-attachments/assets/093f2021-6f5e-40a6-8836-9f59ba44aee5" />
       <img width="600" alt="테이블 페이지 - 테이블 없을 때" src="https://github.com/user-attachments/assets/c59cf52d-7e74-4544-af67-39c644d93ae5" />


<br/>

3. **`axios` 인스턴스 설정 변경**

  ```ts
  export const instance = axios.create({
    baseURL: '/api',
    withCredentials: true,
    headers: {
      'Content-Type': 'application/json',
    },
  });
  ```

<br/>

4. **`next.config.ts`에 rewrites 추가**
  ```ts
  const nextConfig: NextConfig = {
    async rewrites() {
      return [
        {
          source: '/api/:path*',
          destination: 'http://3.39.230.117:8080/api/:path*',
        },
      ];
    },
  };
  ```

<br/>

5. **기존 테이블 api 호출 로직을 React-Query를 사용하는 방식으로 리팩토링**

<br/>

### 테스트
* 로컬 개발 서버 실행 후 `/pos/tables` 페이지에서
  * API 호출 정상 동작 확인
  * Prev/Next 버튼으로 페이지 이동 확인
  * 빈 상태/에러 응답 UI 확인

<br/>

## 참고사항
* 변경된 파일 확인 필요
  * `lib/axios.ts`: axios 인스턴스 baseURL 변경
  * `next.config.ts`: rewrites 설정 추가

<br/>

## 체크리스트
* [x] 코드가 의도한 대로 동작하는지 확인함
* [x] 로컬 테스트로 API 정상 동작 확인
* [x] 관련 문서/코멘트 수정
* [x] 셀프 리뷰 완료
