### PR TITLE
Feat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "axios": "^1.12.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "js-cookie": "^3.0.5",
         "lucide-react": "^0.544.0",
         "next": "15.5.3",
         "pretendard": "^1.3.9",
@@ -4677,6 +4678,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/js-tokens": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "pretendard": "^1.3.9",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
         "zustand": "^5.0.8"
       },
@@ -6174,6 +6175,16 @@
       "optional": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "pretendard": "^1.3.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
     "zustand": "^5.0.8"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "axios": "^1.12.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "js-cookie": "^3.0.5",
     "lucide-react": "^0.544.0",
     "next": "15.5.3",
     "pretendard": "^1.3.9",

--- a/src/app/api/login.ts
+++ b/src/app/api/login.ts
@@ -1,0 +1,17 @@
+import { instance } from '@/lib/axios';
+
+export type LoginRequest = {
+  loginId: string;
+  password: string;
+};
+
+export type LoginResponse = {
+  token: string;
+};
+
+export async function postLogin(
+  loginInfo: LoginRequest,
+): Promise<LoginResponse> {
+  const { data } = await instance.post<LoginResponse>('/user/login', loginInfo);
+  return data;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import Providers from './providers';
+import { Toaster } from 'sonner';
 import '@/styles/globals.css';
 
 export const metadata: Metadata = {
@@ -15,7 +16,10 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="antialiased">
-        <Providers>{children}</Providers>
+        <Providers>
+          {children}
+          <Toaster richColors position="bottom-center" />
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import Image from 'next/image';
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 import useLogin from '@/hooks/useLogin';
 
 import Link from 'next/link';
@@ -33,7 +34,7 @@ export default function Home() {
         router.push('/pos');
       },
       onError: () => {
-        alert('로그인에 실패했습니다.');
+        toast.error('로그인에 실패했습니다.');
       },
     });
   };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,9 @@
 'use client';
 import Image from 'next/image';
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import useLogin from '@/hooks/useLogin';
+
 import Link from 'next/link';
 import Logo from '@/components/Logo';
 import Input from '@/components/Input';
@@ -8,9 +11,12 @@ import Button from '@/components/Button';
 
 export default function Home() {
   const [userInfo, setUserInfo] = useState({
-    id: '',
-    pwd: '',
+    loginId: '',
+    password: '',
   });
+
+  const router = useRouter();
+  const { mutate, isPending, error } = useLogin();
 
   const handleUserInfoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { name, value } = e.target;
@@ -18,6 +24,18 @@ export default function Home() {
       ...prev,
       [name]: value,
     }));
+  };
+
+  const handleLoginClick = () => {
+    mutate(userInfo, {
+      onSuccess: (res) => {
+        localStorage.setItem('accessToken', res.token);
+        router.push('/pos');
+      },
+      onError: () => {
+        alert('로그인에 실패했습니다.');
+      },
+    });
   };
 
   return (
@@ -53,14 +71,14 @@ export default function Home() {
               type="text"
               placeholder="아이디를 입력하세요"
               className="h-12"
-              name="id"
+              name="loginId"
               onChange={handleUserInfoChange}
             />
             <Input
               type="password"
               placeholder="비밀번호를 입력하세요"
               className="h-12"
-              name="pwd"
+              name="password"
               onChange={handleUserInfoChange}
             />
             <div className="w-full max-w-sm flex justify-end">
@@ -76,6 +94,7 @@ export default function Home() {
             <Button
               variant="default"
               className="w-full max-w-sm h-12 mt-2 mx-auto"
+              onClick={handleLoginClick}
             >
               로그인
             </Button>

--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { postLogin, LoginRequest, LoginResponse } from '@/app/api/login';
+
+export default function useLogin() {
+  return useMutation<LoginResponse, Error, LoginRequest>({
+    mutationFn: (body: LoginRequest) => postLogin(body),
+  });
+}

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -5,6 +5,6 @@ export const instance = axios.create({
   withCredentials: true,
   headers: {
     'Content-Type': 'application/json',
-    Authorization: `${localStorage.getItem('accessToken')}`,
+    Authorization: `Bearer ${localStorage.getItem('accessToken')}`,
   },
 });


### PR DESCRIPTION
# PR 템플릿 양식

## 변경 사항

- 기존 axios.ts의 instance에서 Header 앞에 Bearer 추가

## 작업 내용

- 로그인 기능 추가
- npm install sonner, npm install js-cookie
- toast UI 추가
- axios.ts 수정

### 주요 변경 사항 및 스크린샷
<img width="1911" height="934" alt="image" src="https://github.com/user-attachments/assets/d58d1cac-a72d-4fd9-adb7-b237dc53df65" />

- 로그인 실패 시 toast UI 부착 
``` 
// 사용법
import { toast } from 'sonner';
toast.success('로그인에 성공했습니다.');
toast.error('로그인에 실패했습니다.');
``` 

### 테스트

- 실패했을 때 Toast UI 출력 성공
- 이미 부착된 타 API 정상적으로 작동

## 참고사항

- 로그인 성공시에는 Toast UI 출력 안하고 `Router.push` 하는게 깔끔하다고 판단
-  Cookie에 저장 할 계획 원활한 API 호출을 위하여 localStorage 에 `accessToken` 우선 저장 추후 수정
- 로그인해야만 접근 가능한 페이지 분류 미구현 추후 수정

## 체크리스트

- [x] 코드가 의도한 대로 동작하는지 확인함
- [x] 테스트를 추가/수정함
- [x] 관련 문서/코멘트를 수정함
- [x] 셀프 리뷰 완료
