### PR TITLE
feat: 포스 메뉴 페이지 - 카테고리/메뉴 연동 + 주문 내역(로컬 카트) 구현

### DIFF
--- a/src/app/(private)/pos/tables/[tableId]/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/page.tsx
@@ -8,9 +8,7 @@ import { useState } from 'react';
 import { useParams } from 'next/navigation';
 import ConfirmModal from '@/components/ConfirmModal';
 import BackButton from '@/components/BackButton';
-
-// 임시 데이터 - 카테고리
-const categories = ['즐겨찾는 메뉴', '한식', '분식', '양식'];
+import CategoryTab from '@/components/CategoryTab';
 
 // 임시 데이터 - 메뉴 버튼
 const MENU_ITEMS = Array.from({ length: 15 }, (_, i) => ({
@@ -55,24 +53,20 @@ export default function PosMenuPage() {
   const open = (type: ModalType) => setModal(type);
   const close = () => setModal(null);
 
+  const [selectedCategory, setSelectedCategory] = useState<number | 'all'>(
+    'all',
+  );
+
   return (
     <div className="flex h-[89vh] bg-default">
       {/* 왼쪽 메뉴 영역 */}
       <div className="flex-1 flex flex-col ">
         {/* 카테고리 탭 */}
         <div className="bg-white border-b">
-          <div className="flex space-x-1 p-2">
-            {categories.map((category) => (
-              <button
-                key={category}
-                className={
-                  'px-6 py-3 font-medium border-b-2 transition-colors '
-                }
-              >
-                {category}
-              </button>
-            ))}
-          </div>
+          <CategoryTab
+            selected={selectedCategory}
+            onChange={setSelectedCategory}
+          />
         </div>
 
         {/* 메뉴 그리드 영역 */}

--- a/src/app/(private)/pos/tables/[tableId]/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/page.tsx
@@ -4,20 +4,12 @@ import { Trash2, Plus, Minus } from 'lucide-react';
 import MenuButton from '@/components/MenuButton';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useParams } from 'next/navigation';
 import ConfirmModal from '@/components/ConfirmModal';
 import BackButton from '@/components/BackButton';
 import CategoryTab from '@/components/CategoryTab';
-
-// 임시 데이터 - 메뉴 버튼
-const MENU_ITEMS = Array.from({ length: 15 }, (_, i) => ({
-  id: i + 1,
-  name: '돈까스',
-  price: 13000,
-  status: (i + 1) % 7 === 0 ? 'sold-out' : 'available',
-  category: '즐겨찾는 메뉴',
-}));
+import useMenus from '@/hooks/useMenus';
 
 // 임시 데이터 - 주문 내역
 const ORDER_ITEMS = [
@@ -59,6 +51,15 @@ export default function PosMenuPage() {
 
   console.log(selectedCategory);
 
+  const { data, isFetching, isError } = useMenus();
+
+  const filteredMenus = useMemo(() => {
+    if (!data) return [];
+    if (selectedCategory === 'all') return data;
+
+    return data.filter((m) => m.category === selectedCategory);
+  }, [data, selectedCategory]);
+
   return (
     <div className="flex h-[89vh] bg-default">
       {/* 왼쪽 메뉴 영역 */}
@@ -74,16 +75,25 @@ export default function PosMenuPage() {
         {/* 메뉴 그리드 영역 */}
         <div className="flex-1 p-5 overflow-y-auto">
           <div className="grid gap-5 grid-cols-2 md:grid-cols-3 lg:grid-cols-5 h-fit">
-            {MENU_ITEMS.map((item) => (
+            {isFetching && !data && null}
+            {isError && !data && null}
+
+            {filteredMenus.map((item) => (
               <MenuButton
                 key={item.id}
                 name={item.name}
                 price={item.price}
-                status={item.status as 'available' | 'sold-out'}
+                status={item.available ? 'available' : 'sold-out'}
                 category={item.category}
-                onClick={() => null}
+                onClick={() => console.log(item.category)}
               />
             ))}
+
+            {!isFetching && filteredMenus.length === 0 && (
+              <div className="col-span-full text-sm text-gray-400">
+                해당 카테고리에 메뉴가 없습니다.
+              </div>
+            )}
           </div>
         </div>
         <div className="pb-7 pl-4">

--- a/src/app/(private)/pos/tables/[tableId]/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/page.tsx
@@ -84,13 +84,12 @@ export default function PosMenuPage() {
                 name={item.name}
                 price={item.price}
                 status={item.available ? 'available' : 'sold-out'}
-                category={item.category}
                 onClick={() => console.log(item.category)}
               />
             ))}
 
             {!isFetching && filteredMenus.length === 0 && (
-              <div className="col-span-full text-sm text-gray-400">
+              <div className="col-span-full text-gray-400">
                 해당 카테고리에 메뉴가 없습니다.
               </div>
             )}

--- a/src/app/(private)/pos/tables/[tableId]/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/page.tsx
@@ -53,9 +53,11 @@ export default function PosMenuPage() {
   const open = (type: ModalType) => setModal(type);
   const close = () => setModal(null);
 
-  const [selectedCategory, setSelectedCategory] = useState<number | 'all'>(
+  const [selectedCategory, setSelectedCategory] = useState<string | 'all'>(
     'all',
   );
+
+  console.log(selectedCategory);
 
   return (
     <div className="flex h-[89vh] bg-default">

--- a/src/app/api/menu.ts
+++ b/src/app/api/menu.ts
@@ -1,0 +1,14 @@
+import { instance } from '@/lib/axios';
+
+export type MenuItem = {
+  id: number;
+  name: string;
+  price: number;
+  category: string;
+  available: boolean;
+};
+
+export async function getMenus(): Promise<MenuItem[]> {
+  const { data } = await instance.get<MenuItem[]>('/menus');
+  return data;
+}

--- a/src/app/api/pos.ts
+++ b/src/app/api/pos.ts
@@ -6,6 +6,6 @@ export type CategoriesResponse = {
 };
 
 export async function getCategories(): Promise<CategoriesResponse[]> {
-  const { data } = await instance.get('/categories');
+  const { data } = await instance.get<CategoriesResponse[]>('/categories');
   return data;
 }

--- a/src/app/api/pos.ts
+++ b/src/app/api/pos.ts
@@ -1,0 +1,11 @@
+import { instance } from '@/lib/axios';
+
+export type CategoriesResponse = {
+  id: number;
+  name: string;
+};
+
+export async function getCategories(): Promise<CategoriesResponse[]> {
+  const { data } = await instance.get('/categories');
+  return data;
+}

--- a/src/app/api/pos.ts
+++ b/src/app/api/pos.ts
@@ -1,11 +1,11 @@
 import { instance } from '@/lib/axios';
 
-export type CategoriesResponse = {
+export type Category = {
   id: number;
   name: string;
 };
 
-export async function getCategories(): Promise<CategoriesResponse[]> {
-  const { data } = await instance.get<CategoriesResponse[]>('/categories');
+export async function getCategories(): Promise<Category[]> {
+  const { data } = await instance.get<Category[]>('/categories');
   return data;
 }

--- a/src/components/CategoryTab.tsx
+++ b/src/components/CategoryTab.tsx
@@ -1,8 +1,9 @@
 import useCategories from '@/hooks/useCategories';
+import TabButton from '@/components/TabButton';
 
 interface CategoryTabProps {
-  selected: number | 'all';
-  onChange: (v: number | 'all') => void;
+  selected: string | 'all';
+  onChange: (v: string | 'all') => void;
 }
 
 export default function CategoryTab({ selected, onChange }: CategoryTabProps) {
@@ -14,42 +15,19 @@ export default function CategoryTab({ selected, onChange }: CategoryTabProps) {
 
   return (
     <div className="flex gap-1 p-2">
-      <Tab
+      <TabButton
         label="전체"
         active={selected === 'all'}
         onClick={() => onChange('all')}
       />
       {data.map((c) => (
-        <Tab
+        <TabButton
           key={c.id}
           label={c.name}
-          active={selected === c.id}
-          onClick={() => onChange(c.id)}
+          active={selected === c.name}
+          onClick={() => onChange(c.name)}
         />
       ))}
     </div>
-  );
-}
-
-function Tab({
-  label,
-  active,
-  onClick,
-}: {
-  label: string;
-  active: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={`px-6 py-3 font-medium border-b-2 transition-colors ${
-        active
-          ? 'border-blue-500 text-blue-600'
-          : 'border-transparent text-gray-600 hover:text-gray-900'
-      }`}
-    >
-      {label}
-    </button>
   );
 }

--- a/src/components/CategoryTab.tsx
+++ b/src/components/CategoryTab.tsx
@@ -1,11 +1,55 @@
-interface CategoriyTabProps {
+import useCategories from '@/hooks/useCategories';
+
+interface CategoryTabProps {
   selected: number | 'all';
   onChange: (v: number | 'all') => void;
 }
 
-export default function CategoriyTab({
-  selected,
-  onChange,
-}: CategoriyTabProps) {
-  return <div></div>;
+export default function CategoryTab({ selected, onChange }: CategoryTabProps) {
+  const { data, isFetching, isError } = useCategories();
+
+  if (isFetching) return <div className="p-2 text-sm text-gray-400">로딩…</div>;
+  if (isError || !data)
+    return <div className="p-2 text-sm text-red-500">불러오기 실패</div>;
+
+  return (
+    <div className="flex gap-1 p-2">
+      <Tab
+        label="전체"
+        active={selected === 'all'}
+        onClick={() => onChange('all')}
+      />
+      {data.map((c) => (
+        <Tab
+          key={c.id}
+          label={c.name}
+          active={selected === c.id}
+          onClick={() => onChange(c.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function Tab({
+  label,
+  active,
+  onClick,
+}: {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-6 py-3 font-medium border-b-2 transition-colors ${
+        active
+          ? 'border-blue-500 text-blue-600'
+          : 'border-transparent text-gray-600 hover:text-gray-900'
+      }`}
+    >
+      {label}
+    </button>
+  );
 }

--- a/src/components/CategoryTab.tsx
+++ b/src/components/CategoryTab.tsx
@@ -1,0 +1,11 @@
+interface CategoriyTabProps {
+  selected: number | 'all';
+  onChange: (v: number | 'all') => void;
+}
+
+export default function CategoriyTab({
+  selected,
+  onChange,
+}: CategoriyTabProps) {
+  return <div></div>;
+}

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -31,13 +31,22 @@ export default function ConfirmModal({
   onConfirm,
 }: ConfirmModalProps) {
   const handleConfirm = async () => {
-    await onConfirm(); // 이후 API 연결
-    onOpenChange(false); // 명시적으로 닫기
+    await onConfirm();
+    onOpenChange(false);
   };
 
   return (
     <AlertDialog open={open}>
-      <AlertDialogContent className="sm:max-w-[420px]">
+      <AlertDialogContent
+        className="sm:max-w-[420px]"
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.preventDefault();
+            e.stopPropagation();
+            handleConfirm();
+          }
+        }}
+      >
         <AlertDialogHeader>
           <AlertDialogTitle className="text-center">{title}</AlertDialogTitle>
           {description && (
@@ -57,6 +66,7 @@ export default function ConfirmModal({
           <AlertDialogAction
             onClick={handleConfirm}
             className="sm:w-28 bg-red-600 hover:bg-red-700"
+            autoFocus
           >
             {confirmText}
           </AlertDialogAction>

--- a/src/components/MenuButton.tsx
+++ b/src/components/MenuButton.tsx
@@ -4,7 +4,6 @@ interface MenuButtonProps {
   name: string;
   price: number;
   status: 'available' | 'sold-out';
-  category: string;
   onClick: () => void;
 }
 
@@ -12,7 +11,6 @@ export default function MenuButton({
   name,
   price,
   status,
-  category,
   onClick,
 }: MenuButtonProps) {
   const isOutOfStock = status === 'sold-out';
@@ -20,7 +18,7 @@ export default function MenuButton({
   return (
     <Button
       variant="outline"
-      className={`h-32 w-[clamp(14rem, 20vw, 48px)] flex flex-col justify-between p-4 relative  ${
+      className={`h-32 w-[clamp(14rem, 22vw, 48rem)] flex flex-col justify-between p-4 relative  ${
         isOutOfStock ? 'bg-gray-100 text-gray-500  hover:text-gray-500  ' : ''
       }`}
       onClick={onClick}

--- a/src/components/TabButton.tsx
+++ b/src/components/TabButton.tsx
@@ -1,0 +1,20 @@
+interface TabButtonProps {
+  label: string;
+  active: boolean;
+  onClick: () => void;
+}
+
+export default function TabButton({ label, active, onClick }: TabButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-6 py-3 font-medium border-b-2 transition-colors ${
+        active
+          ? 'border-blue-500 text-blue-600'
+          : 'border-transparent text-gray-600 hover:text-gray-900 cursor-pointer'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,0 +1,11 @@
+import { CategoriesResponse, getCategories } from '@/app/api/pos';
+import { useQuery } from '@tanstack/react-query';
+
+export default function useCategories() {
+  const query = useQuery<CategoriesResponse[]>({
+    queryKey: ['categories'],
+    queryFn: getCategories,
+    staleTime: 5 * 50 * 1000,
+  });
+  return query;
+}

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,8 +1,8 @@
-import { CategoriesResponse, getCategories } from '@/app/api/pos';
+import { Category, getCategories } from '@/app/api/pos';
 import { useQuery } from '@tanstack/react-query';
 
 export default function useCategories() {
-  const query = useQuery<CategoriesResponse[]>({
+  const query = useQuery<Category[]>({
     queryKey: ['categories'],
     queryFn: getCategories,
     staleTime: 5 * 50 * 1000,

--- a/src/hooks/useMenus.ts
+++ b/src/hooks/useMenus.ts
@@ -1,0 +1,12 @@
+import { getMenus, MenuItem } from '@/app/api/menu';
+import { useQuery } from '@tanstack/react-query';
+
+export default function useMenus() {
+  const query = useQuery<MenuItem[]>({
+    queryKey: ['menus'],
+    queryFn: getMenus,
+    staleTime: 60_000,
+  });
+
+  return query;
+}

--- a/src/hooks/useOrderCart.ts
+++ b/src/hooks/useOrderCart.ts
@@ -46,7 +46,7 @@ export default function useOrderCart() {
     setCartItems((prevItems) =>
       prevItems.map((item) =>
         item.menuId === menuId
-          ? { ...item, quantity: item.quantity - 1 }
+          ? { ...item, quantity: Math.max(1, item.quantity - 1) }
           : item,
       ),
     );

--- a/src/hooks/useOrderCart.ts
+++ b/src/hooks/useOrderCart.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useState } from 'react';
+
+interface CartItem {
+  menuId: number;
+  name: string;
+  price: number;
+  quantity: number;
+}
+
+export default function useOrderCart() {
+  const [cartItems, setCartItems] = useState<CartItem[]>([]);
+
+  const addItem = (menu: { id: number; name: string; price: number }) =>
+    setCartItems((prevItems) => {
+      const foundIndex = prevItems.findIndex((item) => item.menuId === menu.id);
+
+      // 이미 있으면 수량만 +1
+      if (foundIndex >= 0) {
+        const updated = [...prevItems];
+        updated[foundIndex] = {
+          ...updated[foundIndex],
+          quantity: updated[foundIndex].quantity + 1,
+        };
+        return updated;
+      }
+
+      // 없으면 새로 추가
+      return [
+        ...prevItems,
+        { menuId: menu.id, name: menu.name, price: menu.price, quantity: 1 },
+      ];
+    });
+
+  const increaseQuantity = (menuId: number) =>
+    setCartItems((prevItems) =>
+      prevItems.map((item) =>
+        item.menuId === menuId
+          ? { ...item, quantity: item.quantity + 1 }
+          : item,
+      ),
+    );
+
+  const decreaseQuantity = (menuId: number) =>
+    setCartItems((prevItems) =>
+      prevItems.map((item) =>
+        item.menuId === menuId
+          ? { ...item, quantity: item.quantity - 1 }
+          : item,
+      ),
+    );
+
+  const removeItem = (menuId: number) =>
+    setCartItems((prevItems) =>
+      prevItems.filter((item) => item.menuId !== menuId),
+    );
+
+  const clearCart = () => setCartItems([]);
+
+  const totalCount = cartItems.reduce((sum, item) => sum + item.quantity, 0);
+
+  const totalPrice = cartItems.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0,
+  );
+
+  const toOrderItems = () =>
+    cartItems.map((item) => ({
+      menuId: item.menuId,
+      quantity: item.quantity,
+    }));
+
+  return {
+    cartItems,
+    addItem,
+    increaseQuantity,
+    decreaseQuantity,
+    removeItem,
+    clearCart,
+    totalCount,
+    totalPrice,
+    toOrderItems,
+  };
+}


### PR DESCRIPTION
# 포스 메뉴 페이지 - 카테고리/메뉴 연동 + 주문 내역(로컬 카트) 구현

## 변경 사항
* 카테고리(`GET /categories`), 메뉴(`GET /menus`) API 연동
* 카테고리 탭 컴포넌트 분리 및 카테고리 선택에 따른 메뉴 필터링 기능 추가
* MenuButton 클릭 시 → 주문 내역(state) 추가 구현 (임시 데이터 제거)
   - useOrderCart 훅: 담기/증가/감소/삭제/전체 비우기 + 총수량/합계 계산
* ConfirmModal 컴포넌트: Enter 키로 확인(Yes) 가능

<br>

## 작업 내용

### 배경
* 메뉴 페이지를 실제 API 데이터에 연결, 메뉴 클릭 시 우측 주문 내역에 누적되도록 하는 기능 구현
* 컨펌 모달 안에서 확인 UX를 키보드로 처리할 수 있도록 개선

<br>

### 주요 변경 사항 및 스크린샷

1. **카테고리/메뉴 데이터 연동**
   * `useMenus()` 훅으로 `GET /menus` 호출
   * `CategoryTab` 컴포넌트에서 `GET /categories` 호출 및 연결


2. **카테고리 별 메뉴 필터링 기능**
   * 카테고리 선택 시 선택 상태(`selectedCategory`)로 카테고리 별 메뉴 필터링
      * 카테고리 내 결과가 없을 때 안내 문구 노출
         ![포스 메뉴 - 필터링](https://github.com/user-attachments/assets/8ee5cd8c-011a-4608-93ec-6995d27c1d55)

<br>

3. **주문 내역(로컬 카트)**
   * **주문 내역 추가 기능**: 각 메뉴 버튼 클릭 시 우측 주문 내역에 해당 메뉴 표시
      * 동일 메뉴 추가 시 수량만 증가하도록 함
   * **주문 증감 기능**: 주문 내역에서 메뉴의 증감 조절 가능
   * **주문 개별 삭제 기능**: 삭제 버튼으로 주문 내역에서 개별 메뉴 삭제 가능
   * **주문 전체 삭제 기능**: 휴지통 클릭 시 주문 내역에 들어간 전체 메뉴 삭제 가능
   * **주문 정보 표시**: 주문 내역에 추가한 메뉴 아이템 총 개수 및 가격 표시
     ![포스 메뉴 - 주문 추가, 감소, 삭제](https://github.com/user-attachments/assets/78a127a7-7e27-473a-8cfc-0f862d75ab4e)
     ![포스 메뉴 - 주문 전체 삭제](https://github.com/user-attachments/assets/85d5be40-0e2f-49f9-b2c7-2efabd84711e)

<br>

3. **확인 모달(ConfirmModal)**
   * Enter 키 입력 시 확인(Yes) 동작하도록 개선

<br>

## 테스트
* [x] 카테고리 탭 클릭 시 해당 카테고리 메뉴만 표시됨
* [x] 메뉴 버튼 클릭 시 우측 주문내역에 항목이 누적됨(동일 메뉴는 수량 +1)
* [x] 수량 증가/감소/삭제/전체 삭제가 즉시 반영됨 (감소는 최소값 1)
* [x] 총 수량/합계가 정확히 계산되어 배지/결제 금액에 반영됨
* [x] Enter 키로 ConfirmModal 확인이 가능함
* [x] 데이터 로딩/에러/빈 결과 상태에서 안전하게 렌더링됨

<br>

## 체크리스트
* [x] 코드가 의도한 대로 동작하는지 확인함
* [x] 테스트(수동) 완료
* [x] 관련 임시 데이터/주석 정리
* [x] 셀프 리뷰 완료
