### PR TITLE
feat: 주문 기능 구현(주문 내역 조회, 생성, 재주문, 취소) 및 API 변경 대응

### DIFF
--- a/src/app/(private)/pos/(shell-layout)/tables/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/tables/page.tsx
@@ -13,6 +13,13 @@ export default function TablesPage() {
 
   const { data, cards, noticeText } = useTables(page);
 
+  console.table(
+    data?.content.map((x) => ({
+      num: x.restaurantTableNumber,
+      status: x.displayStatus,
+    })),
+  );
+
   const pageNumber = data?.number ?? page;
 
   const isFirst = data?.first ?? true;

--- a/src/app/(private)/pos/tables/[tableId]/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/page.tsx
@@ -12,6 +12,7 @@ import CategoryTab from '@/components/CategoryTab';
 import useMenus from '@/hooks/useMenus';
 import useOrderCart from '@/hooks/useOrderCart';
 import { useCreateOrder, useOrder } from '@/hooks/useOrder';
+import ExistingOrderList from '@/components/ExistingOrderList';
 
 type ModalType = 'trash' | 'cancel';
 
@@ -55,7 +56,7 @@ export default function PosMenuPage() {
   const cart = useOrderCart();
 
   // 주문 생성
-  const createOrder = useCreateOrder();
+  const createOrder = useCreateOrder(Number(tableId));
 
   function handleOrderClick() {
     const tableNumber = Number(tableId);
@@ -90,7 +91,7 @@ export default function PosMenuPage() {
     isError: orderIsError,
   } = useOrder(orderId);
 
-  console.log(orderId);
+  console.log(order);
 
   return (
     <div className="flex h-[89vh] bg-default">
@@ -170,6 +171,19 @@ export default function PosMenuPage() {
         <div className="flex-1">
           <div className="h-[400px] overflow-y-auto scrollbar-hide">
             <div className="p-4 space-y-3">
+              {order && !orderIsFetching && !orderIsError && (
+                <>
+                  <ExistingOrderList
+                    items={order.orderItems}
+                    totalPrice={order.totalPrice}
+                  />
+
+                  {cart.cartItems.length > 0 && (
+                    <div className="border-t my-3" />
+                  )}
+                </>
+              )}
+
               {cart.cartItems.map((item) => (
                 <div
                   key={item.menuId}

--- a/src/app/(private)/pos/tables/[tableId]/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/page.tsx
@@ -5,13 +5,13 @@ import MenuButton from '@/components/MenuButton';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
 import { useState, useMemo } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useSearchParams } from 'next/navigation';
 import ConfirmModal from '@/components/ConfirmModal';
 import BackButton from '@/components/BackButton';
 import CategoryTab from '@/components/CategoryTab';
 import useMenus from '@/hooks/useMenus';
 import useOrderCart from '@/hooks/useOrderCart';
-import { useCreateOrder } from '@/hooks/useOrder';
+import { useCreateOrder, useOrder } from '@/hooks/useOrder';
 
 type ModalType = 'trash' | 'cancel';
 
@@ -30,6 +30,8 @@ const MODAL = {
 
 export default function PosMenuPage() {
   const { tableId } = useParams<{ tableId: string }>();
+
+  // 휴지통/주문 취소 컨펌 모달
   const [modal, setModal] = useState<ModalType | null>(null);
 
   const open = (type: ModalType) => setModal(type);
@@ -39,6 +41,7 @@ export default function PosMenuPage() {
     'all',
   );
 
+  // 메뉴
   const { data, isFetching, isError } = useMenus();
 
   const filteredMenus = useMemo(() => {
@@ -48,8 +51,10 @@ export default function PosMenuPage() {
     return data.filter((menu) => menu.category === selectedCategory);
   }, [data, selectedCategory]);
 
+  // 주문 계산
   const cart = useOrderCart();
 
+  // 주문 생성
   const createOrder = useCreateOrder();
 
   function handleOrderClick() {
@@ -72,6 +77,20 @@ export default function PosMenuPage() {
       },
     });
   }
+
+  // 기존 주문 내역
+  const param = useSearchParams();
+  const orderIdParam = param.get('orderId');
+
+  const orderId = orderIdParam ? Number(orderIdParam) : undefined;
+
+  const {
+    data: order,
+    isFetching: orderIsFetching,
+    isError: orderIsError,
+  } = useOrder(orderId);
+
+  console.log(orderId);
 
   return (
     <div className="flex h-[89vh] bg-default">

--- a/src/app/(private)/pos/tables/[tableId]/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/page.tsx
@@ -11,7 +11,12 @@ import BackButton from '@/components/BackButton';
 import CategoryTab from '@/components/CategoryTab';
 import useMenus from '@/hooks/useMenus';
 import useOrderCart from '@/hooks/useOrderCart';
-import { useAddOrder, useCreateOrder, useOrder } from '@/hooks/useOrder';
+import {
+  useAddOrder,
+  useCancelOrder,
+  useCreateOrder,
+  useOrder,
+} from '@/hooks/useOrder';
 import ExistingOrderList from '@/components/ExistingOrderList';
 
 type ModalType = 'trash' | 'cancel';
@@ -99,6 +104,9 @@ export default function PosMenuPage() {
       });
     }
   }
+
+  // 주문 취소
+  const cancelOrder = useCancelOrder(Number(orderId));
 
   return (
     <div className="flex h-[89vh] bg-default">
@@ -286,8 +294,11 @@ export default function PosMenuPage() {
             if (modal === 'trash') {
               cart.clearCart();
             } else if (modal === 'cancel') {
-              // cancelOrder API 호출
-              close();
+              cancelOrder.mutate(undefined, {
+                onSuccess: () => {
+                  cart.clearCart();
+                },
+              });
             }
           }}
         />

--- a/src/app/api/categories.ts
+++ b/src/app/api/categories.ts
@@ -1,9 +1,12 @@
 import { instance } from '@/lib/axios';
+import { getStoreId } from './store';
 
 export type Category = { id: number; name: string };
 
 export async function getCategories(): Promise<Category[]> {
-  const { data } = await instance.get('/categories');
+  const storeId = getStoreId();
+
+  const { data } = await instance.get(`/stores/${storeId}/categories`);
   return data;
 }
 

--- a/src/app/api/login.ts
+++ b/src/app/api/login.ts
@@ -6,12 +6,20 @@ export type LoginRequest = {
 };
 
 export type LoginResponse = {
+  userId: number;
+  username: string;
   token: string;
+  stores: { storeId: number; storeName: string }[];
 };
 
 export async function postLogin(
   loginInfo: LoginRequest,
 ): Promise<LoginResponse> {
   const { data } = await instance.post<LoginResponse>('/user/login', loginInfo);
+
+  if (data.stores?.length > 0) {
+    localStorage.setItem('storeId', String(data.stores[0].storeId));
+  }
+
   return data;
 }

--- a/src/app/api/menu.ts
+++ b/src/app/api/menu.ts
@@ -1,4 +1,5 @@
 import { instance } from '@/lib/axios';
+import { getStoreId } from './store';
 
 export type MenuItem = {
   id: number;
@@ -9,6 +10,8 @@ export type MenuItem = {
 };
 
 export async function getMenus(): Promise<MenuItem[]> {
-  const { data } = await instance.get<MenuItem[]>('/menus');
+  const storeId = getStoreId();
+
+  const { data } = await instance.get<MenuItem[]>(`/stores/${storeId}/menus`);
   return data;
 }

--- a/src/app/api/order.ts
+++ b/src/app/api/order.ts
@@ -22,16 +22,18 @@ export type OrderResponse = {
   paid: boolean;
 };
 
+const storeId = getStoreId();
+
 export async function getOrder(orderId: number) {
-  const { data } = await instance.get<OrderResponse>(`/orders/${orderId}`);
+  const { data } = await instance.get<OrderResponse>(
+    `/stores/${storeId}/orders/${orderId}`,
+  );
   return data;
 }
 
-export async function createOrder(payload: OrderRequest) {
-  const storeId = getStoreId();
-
+export async function createOrder(tableId: number, payload: OrderRequest) {
   const { data } = await instance.post<OrderResponse>(
-    `/stores/${storeId}/orders`,
+    `/stores/${storeId}/tables/${tableId}/orders`,
     payload,
   );
   return data;

--- a/src/app/api/order.ts
+++ b/src/app/api/order.ts
@@ -1,4 +1,5 @@
 import { instance } from '@/lib/axios';
+import { getStoreId } from './store';
 
 export type OrderRequest = {
   restaurantTableNumber: number;
@@ -27,6 +28,11 @@ export async function getOrder(orderId: number) {
 }
 
 export async function createOrder(payload: OrderRequest) {
-  const { data } = await instance.post<OrderResponse>('/orders', payload);
+  const storeId = getStoreId();
+
+  const { data } = await instance.post<OrderResponse>(
+    `/stores/${storeId}/orders`,
+    payload,
+  );
   return data;
 }

--- a/src/app/api/order.ts
+++ b/src/app/api/order.ts
@@ -38,3 +38,13 @@ export async function createOrder(tableId: number, payload: OrderRequest) {
   );
   return data;
 }
+
+export async function addOrder(orderId: number, payload: OrderRequest) {
+  const body = payload.orderItems;
+
+  const { data } = await instance.post<OrderResponse>(
+    `/stores/${storeId}/orders/${orderId}/items`,
+    body,
+  );
+  return data;
+}

--- a/src/app/api/order.ts
+++ b/src/app/api/order.ts
@@ -48,3 +48,10 @@ export async function addOrder(orderId: number, payload: OrderRequest) {
   );
   return data;
 }
+
+export async function cancelOrder(orderId: number) {
+  const { data } = await instance.patch<OrderResponse>(
+    `/stores/${storeId}/orders/${orderId}/cancel`,
+  );
+  return data;
+}

--- a/src/app/api/store.ts
+++ b/src/app/api/store.ts
@@ -1,0 +1,7 @@
+export function getStoreId(): number {
+  const storeId = localStorage.getItem('storeId');
+
+  if (!storeId) throw new Error('storeId가 없습니다. 다시 로그인 해주세요.');
+
+  return Number(storeId);
+}

--- a/src/app/api/tables.ts
+++ b/src/app/api/tables.ts
@@ -1,10 +1,20 @@
 import { instance } from '@/lib/axios';
+import { getStoreId } from './store';
 
 export type TablesResponse = {
   content: {
     id: number;
     restaurantTableNumber: number;
-    status: string;
+    displayStatus: string;
+    activeOrder?: {
+      orderId: number;
+      totalPrice: number;
+      orderItems: {
+        menuName: string;
+        quantity: number;
+        price: number;
+      }[];
+    } | null;
   }[];
   number: number;
   totalPages: number;
@@ -21,7 +31,9 @@ export async function getTables(
   page: number,
   size = PAGE_SIZE,
 ): Promise<TablesResponse> {
-  const { data } = await instance.get('/tables', {
+  const storeId = getStoreId();
+
+  const { data } = await instance.get(`/stores/${storeId}/tables`, {
     params: { page, size },
   });
   return data;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,13 @@ export default function RootLayout({
       <body className="antialiased">
         <Providers>
           {children}
-          <Toaster richColors position="bottom-center" />
+          <Toaster
+            richColors
+            position="bottom-center"
+            toastOptions={{
+              duration: 2000,
+            }}
+          />
         </Providers>
       </body>
     </html>

--- a/src/components/ExistingOrderList.tsx
+++ b/src/components/ExistingOrderList.tsx
@@ -2,8 +2,10 @@ import { OrderResponse } from '@/app/api/order';
 
 export default function ExistingOrderList({
   items,
+  totalPrice,
 }: {
   items: OrderResponse['orderItems'];
+  totalPrice: number;
 }) {
   if (!items.length) return null;
 
@@ -14,15 +16,12 @@ export default function ExistingOrderList({
           key={item.orderItemId}
           className="flex items-center justify-between bg-gray-200 p-4 rounded opacity-80"
         >
-          <div className="flex-1 pl-1">
-            <h4 className="font-medium text-gray-700">
-              {item.menuName} x {item.quantity}
-            </h4>
-            <p className="text-gray-600 text-sm">
-              {(item.itemPrice * item.quantity).toLocaleString()}
-            </p>
-          </div>
-          <span className="text-xs text-gray-500 select-none">기존 주문</span>
+          <p className="font-medium text-gray-700">
+            {item.menuName} x {item.quantity}
+          </p>
+          <span className=" text-gray-500 select-none">
+            {totalPrice.toLocaleString()}
+          </span>
         </div>
       ))}
     </div>

--- a/src/components/MenuButton.tsx
+++ b/src/components/MenuButton.tsx
@@ -29,8 +29,19 @@ export default function MenuButton({
           품절
         </span>
       )}
+
       <div className="text-left w-full">
-        <h3 className="font-semibold text-lg">{name}</h3>
+        <h3
+          className="font-semibold text-lg leading-tight break-words whitespace-normal"
+          style={{
+            display: '-webkit-box',
+            WebkitLineClamp: 2,
+            WebkitBoxOrient: 'vertical',
+            overflow: 'hidden',
+          }}
+        >
+          {name}
+        </h3>
       </div>
 
       <div className="text-right w-full">

--- a/src/hooks/useOrder.ts
+++ b/src/hooks/useOrder.ts
@@ -3,6 +3,7 @@ import {
   OrderRequest,
   createOrder,
   getOrder,
+  addOrder,
 } from '@/app/api/order';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
@@ -30,6 +31,29 @@ export function useCreateOrder(tableId: number) {
 
       router.push('/pos/tables');
       queryClient.invalidateQueries({ queryKey: ['tables'] });
+    },
+    onError: (err) => {
+      toast.error('주문 처리에 실패했습니다.');
+
+      console.error('status:', err?.response?.status);
+      console.error('data:', err?.response?.data);
+    },
+  });
+}
+
+export function useAddOrder(orderId: number) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  return useMutation<OrderResponse, AxiosError<ApiErrorBody>, OrderRequest>({
+    mutationFn: (payload) => addOrder(orderId, payload),
+    onSuccess: (order) => {
+      toast.success('주문이 접수되었습니다.');
+      console.log(order);
+
+      router.push('/pos/tables');
+      queryClient.invalidateQueries({ queryKey: ['tables'] });
+      queryClient.invalidateQueries({ queryKey: ['order', orderId] });
     },
     onError: (err) => {
       toast.error('주문 처리에 실패했습니다.');

--- a/src/hooks/useOrder.ts
+++ b/src/hooks/useOrder.ts
@@ -4,6 +4,7 @@ import {
   createOrder,
   getOrder,
   addOrder,
+  cancelOrder,
 } from '@/app/api/order';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
@@ -57,6 +58,29 @@ export function useAddOrder(orderId: number) {
     },
     onError: (err) => {
       toast.error('주문 처리에 실패했습니다.');
+
+      console.error('status:', err?.response?.status);
+      console.error('data:', err?.response?.data);
+    },
+  });
+}
+
+export function useCancelOrder(orderId: number) {
+  const router = useRouter();
+  const queryClient = useQueryClient();
+
+  return useMutation<OrderResponse, AxiosError<ApiErrorBody>, void>({
+    mutationFn: () => cancelOrder(orderId),
+    onSuccess: (order) => {
+      toast.success('주문이 취소되었습니다.');
+      console.log(order);
+
+      router.push('/pos/tables');
+      queryClient.invalidateQueries({ queryKey: ['tables'] });
+      queryClient.invalidateQueries({ queryKey: ['order', orderId] });
+    },
+    onError: (err) => {
+      toast.error('주문 취소에 실패했습니다.');
 
       console.error('status:', err?.response?.status);
       console.error('data:', err?.response?.data);

--- a/src/hooks/useOrder.ts
+++ b/src/hooks/useOrder.ts
@@ -18,12 +18,12 @@ export function useOrder(orderId?: number) {
   });
 }
 
-export function useCreateOrder() {
+export function useCreateOrder(tableId: number) {
   const router = useRouter();
   const queryClient = useQueryClient();
 
   return useMutation<OrderResponse, AxiosError<ApiErrorBody>, OrderRequest>({
-    mutationFn: (payload) => createOrder(payload),
+    mutationFn: (payload) => createOrder(tableId, payload),
     onSuccess: (order) => {
       toast.success('주문이 접수되었습니다.');
       console.log(order);

--- a/src/hooks/useTables.ts
+++ b/src/hooks/useTables.ts
@@ -10,17 +10,26 @@ export default function useTables(page: number) {
     placeholderData: keepPreviousData,
   });
 
+  const toUIStatus = (s: string): 'EMPTY' | 'ORDERED' | 'SERVED' => {
+    if (s === 'EMPTY') return 'EMPTY';
+    if (s === 'SERVED') return 'SERVED';
+    return 'ORDERED';
+  };
+
   const cards: TableCardProps[] =
-    query.data?.content.map((item) => ({
-      tableNumber: item.restaurantTableNumber,
-      status:
-        item.status === 'EMPTY'
-          ? 'EMPTY'
-          : item.status === 'SERVED'
-          ? 'SERVED'
-          : 'ORDERED',
-      href: `/pos/tables/${item.restaurantTableNumber}`,
-    })) ?? [];
+    query.data?.content.map((item) => {
+      const status = toUIStatus(item.displayStatus);
+
+      return {
+        tableNumber: item.restaurantTableNumber,
+        status,
+        href: `/pos/tables/${item.restaurantTableNumber}`,
+        price: item.activeOrder?.totalPrice,
+        menuItems:
+          item.activeOrder?.orderItems?.map((o) => o.menuName).slice(0, 2) ??
+          [],
+      };
+    }) ?? [];
 
   return {
     data: query.data,

--- a/src/hooks/useTables.ts
+++ b/src/hooks/useTables.ts
@@ -19,11 +19,14 @@ export default function useTables(page: number) {
   const cards: TableCardProps[] =
     query.data?.content.map((item) => {
       const status = toUIStatus(item.displayStatus);
+      const href = item.activeOrder?.orderId
+        ? `/pos/tables/${item.restaurantTableNumber}?orderId=${item.activeOrder.orderId}`
+        : `/pos/tables/${item.restaurantTableNumber}`;
 
       return {
         tableNumber: item.restaurantTableNumber,
         status,
-        href: `/pos/tables/${item.restaurantTableNumber}`,
+        href,
         price: item.activeOrder?.totalPrice,
         menuItems:
           item.activeOrder?.orderItems?.map((o) => o.menuName).slice(0, 2) ??

--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -1,0 +1,7 @@
+export type ApiErrorBody = {
+  errorCode?: string;
+  title?: string;
+  message?: string;
+  detail?: string;
+  timestamp?: string;
+};


### PR DESCRIPTION

# 주문 기능 구현(주문 내역 조회, 생성, 재주문, 취소) 및 API 변경 대응

## 변경 사항
* BE API 스키마/경로 변경으로 기존 API 호출 코드 수정
  * `GET /tables`, `GET /menus`, `GET /categories`
* 주문 플로우 기능 개발
  - 기존 주문 내역 불러오기: `order GET`
  - 주문 생성: `order POST`
  - 재주문: `order items POST`
  - 주문 취소: `order cancel PATCH`
* UI/UX 개선
  * `ExistingOrderList` 컴포넌트: UI 수정, 합계 금액을 서버 값 기준으로 표시
  * 메뉴 버튼 컴포넌트: 긴 이름 2줄 제한 및 초과 `...` 처리
  * 토스트 노출 시간 `2s`로 단축
* 기타
  * 로그인 응답 타입 수정 및 `storeId` LocalStorage 저장/조회 유틸 추가
  * 에러 타입 정의 파일 생성
  * 쿼리 스트링으로 `orderId` 전달 로직 추가
  * 콘솔 로깅(에러, 데이터 개수 등) 정비

<br/>

## 작업 내용

### 배경
* 백엔드 응답 스키마 및 엔드포인트가 변경되어 프론트 API 호출부/타입 전반의 정리 필요
* 테이블 별 진행 중 주문이 있는 경우 재주문(기존 주문에 아이템 추가)과 주문 취소 등 POS 핵심 플로우 완성 필요
* 메뉴명이 긴 경우 버튼 레이아웃이 깨지는 문제가 있어 접근성/가독성 개선

<br/>

### 주요 변경 사항 및 스크린샷

* **API 및 타입 정리**
  * 로그인 API 변경에 따른 응답 타입 수정, `storeId`를 LocalStorage에 저장 및 조회하는 유틸 함수 추가
  * `Tables` 응답 타입에 맞춰 status 매핑, 가격/메뉴 아이템 필드 반영
  * BE 변경에 따라 API 경로 일괄 수정

<br/>

* **주문 플로우**
  * **기존 주문 내역 조회**: `useOrder(orderId)` 쿼리 훅 추가
  * **주문 생성**: `useCreateOrder(tableId)` 뮤테이션 훅
    * 성공 시 토스트, 테이블 목록 쿼리 무효화(`['tables']`), 카트 초기화
        ![포스 메뉴 - 주문 생성, 주문 내역](https://github.com/user-attachments/assets/e099ae7a-81d7-46ac-aaf5-6852d6bb2138)
  * **재주문**: `useReorder(orderId)` 뮤테이션 훅
    * `orderId` 존재 시 `POST /orders/{orderId}/items` 호출
    * 없으면 최초 주문(`createOrder`)로 분기
       ![포스 메뉴 - 재주문](https://github.com/user-attachments/assets/f16c85f8-e541-42dc-bfb3-785cb70d4394)
  * **주문 취소**: `useCancelOrder(orderId)` 뮤테이션 훅
    * 성공 시 토스트, 테이블/주문 쿼리 무효화

<br/>

* **UI/컴포넌트**
  * `ExistingOrderList` 컴포넌트: 서버 제공 합계 금액을 그대로 표시하도록 수정, 항목/수량/금액 레이아웃 정리
  * 토스트: 성공/실패 메시지 `duration 2000ms` 로 설정
  * `MenuButton` 컴포넌트: 기본 `nowrap` 제거 → 줄바꿈 허용, 최대 2줄 + 초과 숨김/말줄임 처리
<p align="center">
   <img width="45%" alt="(B) 메뉴버튼 - 이름 제한 추가 " src="https://github.com/user-attachments/assets/9a9e2f6d-56c2-473b-b9cf-9cdfa01d2e12" />
   <img width="45%" alt="(A) 메뉴버튼 - 이름 제한 추가 " src="https://github.com/user-attachments/assets/892e4ddd-9fbf-48fe-8e3d-28438f1d8b79" />
</p>

<br/>

### 테스트

* **주문 플로우**
  * 최초 주문(카트에 아이템 있음 / 없음) 분기 동작
  * 기존 주문 존재 시 재주문 경로로 분기되는지 확인
  * 주문 취소 후 테이블/주문 데이터 재조회(쿼리 무효화) 확인

* **API/타입**
  * `GET /tables`, `GET /menus`, `GET /categories` 정상 렌더링 및 타입 오류 없음

* **UI/UX**
  * 메뉴명 2줄 초과 시 말줄임 처리 확인(해상도별)
  * 토스트 노출 시간 2초 적용 확인
  * 기존 주문 합계 금액이 서버 값과 일치하는지 확인

* **기타**
  * `storeId` LocalStorage 저장 및 조회 정상
  * `orderId` 쿼리스트링 전달 → 주문 페이지에서 활용되는지 확인

<br/>

## 체크리스트
* [x] 코드가 의도한 대로 동작하는지 확인함
* [x] 테스트를 추가/수정함
* [x] 관련 문서/코멘트를 수정함
* [x] 셀프 리뷰 완료
