### PR TITLE
Feat/signup: accessToken 만료시 로그인 페이지로 리다이렉트 구현, 로그인페이지 수정, Button 컴포넌트 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1969,6 +1969,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
       "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.2"
       },
@@ -2045,6 +2046,7 @@
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2055,6 +2057,7 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2105,6 +2108,7 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -2622,6 +2626,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3568,6 +3573,7 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3742,6 +3748,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5964,6 +5971,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5973,6 +5981,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6766,6 +6775,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6925,6 +6935,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/app/(private)/layout.tsx
+++ b/src/app/(private)/layout.tsx
@@ -1,0 +1,66 @@
+// app/(private)/layout.tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, usePathname, useSearchParams } from 'next/navigation';
+
+export default function PrivateLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const sp = useSearchParams();
+  const [ready, setReady] = useState(false); // FOUC 방지용
+
+  useEffect(() => {
+    const token =
+      typeof window !== 'undefined'
+        ? localStorage.getItem('accessToken')
+        : null;
+
+    if (!token) {
+      const next = encodeURIComponent(
+        `${pathname}${sp?.toString() ? `?${sp}` : ''}`,
+      );
+      router.replace(`/?next=${next}`);
+      return;
+    }
+
+    try {
+      const [, payloadB64] = token.split('.');
+      if (payloadB64) {
+        const payload = JSON.parse(atob(payloadB64));
+        if (payload.exp && Date.now() >= payload.exp * 1000) {
+          // 만료 시 토큰 삭제 + 리다이렉트
+          localStorage.removeItem('accessToken');
+          const next = encodeURIComponent(
+            `${pathname}${sp?.toString() ? `?${sp}` : ''}`,
+          );
+          router.replace(`/?next=${next}`);
+          return;
+        }
+      }
+    } catch {
+      localStorage.removeItem('accessToken');
+      const next = encodeURIComponent(
+        `${pathname}${sp?.toString() ? `?${sp}` : ''}`,
+      );
+      router.replace(`/?next=${next}`);
+      return;
+    }
+
+    setReady(true);
+  }, [router, pathname, sp]);
+
+  if (!ready) {
+    return (
+      <div className="min-h-screen flex items-center justify-center text-gray-500">
+        인증 확인 중…
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/src/app/(private)/pos/(shell-layout)/products/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/page.tsx
@@ -25,7 +25,13 @@ export default function Page() {
     router.push(`/pos/products/${p.id}/edit?${q}`, { scroll: false });
   };
   if (isLoading) return <div>로딩 중...</div>;
-  if (error) return <div>{noticeText}</div>;
+  if (error)
+    return (
+      <div>
+        {noticeText}
+        {console.log(error)}
+      </div>
+    );
   return (
     <div className="min-w-[500px] mx-auto w-full md:w-[50%] lg:w-[70%] max-w-[1200px] px-4">
       <h1 className="font-bold my-5 text-4xl md:text-5xl">상품 관리</h1>

--- a/src/app/(private)/pos/(shell-layout)/products/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/page.tsx
@@ -25,13 +25,10 @@ export default function Page() {
     router.push(`/pos/products/${p.id}/edit?${q}`, { scroll: false });
   };
   if (isLoading) return <div>로딩 중...</div>;
-  if (error)
-    return (
-      <div>
-        {noticeText}
-        {console.log(error)}
-      </div>
-    );
+  if (error) {
+    console.log(error);
+  }
+  return <div>{noticeText}</div>;
   return (
     <div className="min-w-[500px] mx-auto w-full md:w-[50%] lg:w-[70%] max-w-[1200px] px-4">
       <h1 className="font-bold my-5 text-4xl md:text-5xl">상품 관리</h1>

--- a/src/app/api/signup.ts
+++ b/src/app/api/signup.ts
@@ -1,0 +1,27 @@
+import { instance } from '@/lib/axios';
+
+export type SignupRequest = {
+  loginId: string;
+  password: string;
+  phoneNumber: string;
+  username: string;
+  storeName: string;
+  tableCount: number;
+};
+
+export type SignupResponse = {
+  userId: number;
+  loginId: string;
+  username: string;
+  storeName: string;
+};
+
+export async function postSignUp(
+  signupInfo: SignupRequest,
+): Promise<SignupResponse> {
+  const { data } = await instance.post<SignupResponse>(
+    '/user/signup',
+    signupInfo,
+  );
+  return data;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -68,37 +68,46 @@ export default function Home() {
             <h1 className="text-black text-[40px] font-bold text-center mt-5 mb-5">
               SERVE NOW
             </h1>
-            <Input
-              type="text"
-              placeholder="아이디를 입력하세요"
-              className="h-12"
-              name="loginId"
-              onChange={handleUserInfoChange}
-            />
-            <Input
-              type="password"
-              placeholder="비밀번호를 입력하세요"
-              className="h-12"
-              name="password"
-              onChange={handleUserInfoChange}
-            />
-            <div className="w-full max-w-sm flex justify-end">
-              <Link href="/signup" className="self-end px-0 mt-2">
-                <Button
-                  variant="link"
-                  className="px-0 mt-2 text-[#BBBBBB] hover:text-black transition-colors"
-                >
-                  회원가입
-                </Button>
-              </Link>
-            </div>
-            <Button
-              variant="default"
-              className="w-full max-w-sm h-12 mt-2 mx-auto"
-              onClick={handleLoginClick}
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                handleLoginClick();
+              }}
+              className="flex flex-col w-full max-w-sm"
             >
-              로그인
-            </Button>
+              <Input
+                type="text"
+                placeholder="아이디를 입력하세요"
+                className="h-12"
+                name="loginId"
+                onChange={handleUserInfoChange}
+              />
+              <Input
+                type="password"
+                placeholder="비밀번호를 입력하세요"
+                className="h-12"
+                name="password"
+                onChange={handleUserInfoChange}
+              />
+              <div className="w-full max-w-sm flex justify-end">
+                <Link href="/signup" className="self-end px-0 mt-2">
+                  <Button
+                    variant="link"
+                    type="button"
+                    className="px-0 mt-2 text-[#BBBBBB] hover:text-black transition-colors"
+                  >
+                    회원가입
+                  </Button>
+                </Link>
+              </div>
+              <Button
+                type="submit"
+                variant="default"
+                className="w-full max-w-sm h-12 mt-2 mx-auto"
+              >
+                로그인
+              </Button>
+            </form>
           </div>
         </div>
       </div>

--- a/src/app/signup/layout.tsx
+++ b/src/app/signup/layout.tsx
@@ -4,7 +4,6 @@ export default function PosMenuLayout({
   children,
 }: {
   children: React.ReactNode;
-  modal: React.ReactNode;
 }) {
   return (
     <>

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -1,22 +1,58 @@
 'use client';
 import React from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
+
+import { toast } from 'sonner';
+
 import Button from '@/components/Button';
+import useSignup from '@/hooks/useSignup';
 
 const signupCategory = [
-  { type: 'text', placeholder: '아이디' },
-  { type: 'password', placeholder: '비밀번호' },
+  { type: 'text', placeholder: '아이디', name: 'loginId' },
+  { type: 'password', placeholder: '비밀번호', name: 'password' },
+  { type: 'text', placeholder: '사용자명', name: 'username' },
   {
     type: 'text',
     placeholder: '핸드폰( -는 빼고 입력해주세요 )',
     inputMode: 'numeric',
     maxLength: 11,
+    name: 'phoneNumber',
   },
-  { type: 'text', placeholder: '매장명' },
-  { type: 'number', placeholder: '매장 테이블 수', min: 0 },
+  { type: 'text', placeholder: '매장명', name: 'storeName' },
+  { type: 'number', placeholder: '매장 테이블 수', min: 0, name: 'tableCount' },
 ];
 
 const singnup = () => {
+  const [signupInfo, setSignupInfo] = useState({
+    loginId: '',
+    password: '',
+    phoneNumber: '',
+    username: '',
+    storeName: '',
+    tableCount: 0,
+  });
+
+  const { mutate: signupFn, isPending } = useSignup();
+  console.log(signupInfo);
+  const handleInfoChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setSignupInfo((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmitClick = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    signupFn(signupInfo, {
+      onSuccess: (res) => {
+        toast.success('회원가입 성공!');
+        console.log('서버 응답:', res);
+      },
+      onError: (err) => {
+        toast.error(`회원가입 실패: ${err.message}`);
+      },
+    });
+  };
+
   return (
     <div className="flex items-center justify-center min-h-screen bg-gray-50">
       <div className="w-full max-w-md bg-white shadow-lg rounded-2xl p-8">
@@ -24,7 +60,7 @@ const singnup = () => {
           <h2 className="text-2xl font-bold text-center">회원가입</h2>
         </div>
         {/* 회원가입 폼 */}
-        <form className="space-y-4">
+        <form className="space-y-4" onSubmit={handleSubmitClick}>
           {signupCategory.map((field, idx) => (
             <div key={idx}>
               <input
@@ -43,6 +79,8 @@ const singnup = () => {
                       }
                     : undefined
                 }
+                onChange={handleInfoChange}
+                name={field.name}
               />
             </div>
           ))}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -13,6 +13,7 @@ interface ButtonProps {
   onClick?: () => void;
   disabled?: boolean;
   className?: string;
+  type?: 'button' | 'submit' | 'reset';
 }
 
 export default function Button({
@@ -22,6 +23,7 @@ export default function Button({
   onClick,
   disabled,
   className,
+  ...props
 }: ButtonProps) {
   return (
     <UIButton
@@ -30,6 +32,7 @@ export default function Button({
       onClick={onClick}
       disabled={disabled}
       className={className}
+      {...props}
     >
       {children}
     </UIButton>

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -1,0 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+import { postSignUp, SignupRequest, SignupResponse } from '@/app/api/signup';
+
+export default function useSignup() {
+  return useMutation<SignupResponse, Error, SignupRequest>({
+    mutationFn: (body: SignupRequest) => postSignUp(body),
+  });
+}


### PR DESCRIPTION
# PR 템플릿 양식

## 작업 내용
- Button컴포넌트에 `type` 속성 추가 `{...props}` 추가
- 로그인 페이지 form 태그로 변경하여 엔터 입력 시 로그인 가능
- (private)하위 경로에 있는 페이지들에 대하여 accessToken없이 접근 시 로그인 페이지로 리다이렉트
- 토큰 만료시 로그인 페이지로 redirect (서버에서 쿠키에 내려주는게 아니라서 midware를 따로 설정해 주어야 하므로 간단하게 accessToken의 exp부분만을 비교하여 만료 판단) 

### 배경
- 로그인 할 때마다 엔터가 자연스러운데 안되고 마우스로 클릭하는게 불편하여 수정
- 작업하다가 로그인이 만료되어 API 호출이 안되서 직접 로그인 URL로 이동하여 재로그인을 해주었는데 불편하여 수정


### 주요 변경 사항 및 스크린샷

<img width="1191" height="941" alt="image" src="https://github.com/user-attachments/assets/74d5492b-b456-46d7-9f2c-33399ae9fa09" />

- 로그인 만료시 `alert` 창을 통하여 알림 표시

### 테스트
- `accessToken` 없이 (private)안 페이지 접근 시 리다이렉트 확인
- `accessToken` 의 exp부분을 과거 시간대로 조작하여 접근 시 리다이렉트 확인
- 로그인 Enter키로 로그인 되는 지 확인

## 참고사항

- 추후 midware를 구현하여 들어오는 accessToken을 HttpOnly 쿠키로 사용 할 지 고민중

## 체크리스트

- [x] 코드가 의도한 대로 동작하는지 확인함
- [x] 테스트를 추가/수정함
- [x] 관련 문서/코멘트를 수정함
- [x] 셀프 리뷰 완료
