### PR TITLE
Feat/admin : pos/products 하위 Modal 관련 direct 접근 및 새로고침 시 정상화

### DIFF
--- a/src/app/(private)/pos/(shell-layout)/products/@modal/(.)[productId]/edit/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/@modal/(.)[productId]/edit/page.tsx
@@ -19,7 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 
-export default function EditProductModal() {
+export default function EditProductModal({ id }: { id: string }) {
   const router = useRouter();
   const params = useParams<{ productId: string }>();
   const sp = useSearchParams();
@@ -29,7 +29,6 @@ export default function EditProductModal() {
       name: sp.get('name') ?? '',
       price: sp.get('price') ?? '',
       categoryName: sp.get('category') ?? '',
-      // 'available'이 '판매중' | '품절'로 들어오는 페이지 구조에 맞춤
       available: (sp.get('available') ?? '판매중') === '판매중',
     }),
     [sp],

--- a/src/app/(private)/pos/(shell-layout)/products/@modal/(.)new/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/@modal/(.)new/page.tsx
@@ -58,7 +58,7 @@ export default function NewProductModal() {
         <div className="flex justify-between items-center mb-6">
           <h2 className="text-xl font-bold">상품 추가</h2>
           <button onClick={() => router.back()}>
-            <X className="w-6 h-6 text-gray-500 hover:text-black" />
+            <X className="w-6 h-6 text-gray-500 hover:text-black cursor-pointer" />
           </button>
         </div>
 

--- a/src/app/(private)/pos/(shell-layout)/products/@modal/(.)new/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/@modal/(.)new/page.tsx
@@ -16,7 +16,6 @@ import {
   SelectItem,
   SelectValue,
 } from '@/components/ui/select';
-import { toast } from 'sonner';
 
 type NewProduct = {
   name: string;

--- a/src/app/(private)/pos/(shell-layout)/products/[productId]/edit/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/[productId]/edit/page.tsx
@@ -1,0 +1,9 @@
+import { redirect } from 'next/navigation';
+
+export default function EditStandalone({
+  params,
+}: {
+  params: { productId: string };
+}) {
+  redirect(`/pos/products`);
+}

--- a/src/app/(private)/pos/(shell-layout)/products/[productId]/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/[productId]/page.tsx
@@ -1,7 +1,0 @@
-import React from 'react';
-
-const page = () => {
-  return <div>page</div>;
-};
-
-export default page;

--- a/src/app/(private)/pos/(shell-layout)/products/new/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/new/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function NewProductStandalone() {
+  redirect('/pos/products?open=new');
+}

--- a/src/app/(private)/pos/(shell-layout)/products/newCategory/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/newCategory/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function NewCategoryStandalone() {
+  redirect('/pos/products?open=newCategory');
+}

--- a/src/app/(private)/pos/(shell-layout)/products/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/page.tsx
@@ -1,11 +1,12 @@
 'use client';
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams, useRouter } from 'next/navigation';
 import { useProducts, useDeleteProduct } from '@/hooks/useProducts';
 import { Search, X, Settings, Trash2 } from 'lucide-react';
 import Button from '@/components/Button';
 import NewProductModal from './@modal/(.)new/page';
+import NewCategoryModal from './@modal/(.)newCategory/page';
 
 export default function Page() {
   const { mutate: deleteProduct } = useDeleteProduct();
@@ -13,7 +14,7 @@ export default function Page() {
   const [searchName, setSearchName] = useState('');
   const searchParams = useSearchParams();
   const router = useRouter();
-  const openNew = searchParams.get('open') === 'new';
+  const open = searchParams.get('open');
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setSearchName(e.target.value);
@@ -107,7 +108,8 @@ export default function Page() {
             ))}
           </tbody>
         </table>
-        {openNew && <NewProductModal />}
+        {open === 'new' && <NewProductModal />}
+        {open === 'newCategory' && <NewCategoryModal />}
       </div>
     </div>
   );

--- a/src/app/(private)/pos/(shell-layout)/products/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/page.tsx
@@ -7,6 +7,7 @@ import { Search, X, Settings, Trash2 } from 'lucide-react';
 import Button from '@/components/Button';
 import NewProductModal from './@modal/(.)new/page';
 import NewCategoryModal from './@modal/(.)newCategory/page';
+import EditProductModal from './@modal/(.)[productId]/edit/page';
 
 export default function Page() {
   const { mutate: deleteProduct } = useDeleteProduct();
@@ -14,8 +15,8 @@ export default function Page() {
   const [searchName, setSearchName] = useState('');
   const searchParams = useSearchParams();
   const router = useRouter();
-  const open = searchParams.get('open');
-
+  const sp = useSearchParams();
+  const open = sp.get('open');
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setSearchName(e.target.value);
 

--- a/src/app/(private)/pos/(shell-layout)/products/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/products/page.tsx
@@ -1,16 +1,19 @@
 'use client';
 import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useSearchParams, useRouter } from 'next/navigation';
 import { useProducts, useDeleteProduct } from '@/hooks/useProducts';
 import { Search, X, Settings, Trash2 } from 'lucide-react';
 import Button from '@/components/Button';
+import NewProductModal from './@modal/(.)new/page';
 
 export default function Page() {
   const { mutate: deleteProduct } = useDeleteProduct();
   const { rows, isLoading, error, noticeText } = useProducts();
   const [searchName, setSearchName] = useState('');
+  const searchParams = useSearchParams();
   const router = useRouter();
+  const openNew = searchParams.get('open') === 'new';
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setSearchName(e.target.value);
@@ -24,8 +27,10 @@ export default function Page() {
     }).toString();
     router.push(`/pos/products/${p.id}/edit?${q}`, { scroll: false });
   };
+
   if (isLoading) return <div>로딩 중...</div>;
   if (error) return <div>{noticeText}</div>;
+
   return (
     <div className="min-w-[500px] mx-auto w-full md:w-[50%] lg:w-[70%] max-w-[1200px] px-4">
       <h1 className="font-bold my-5 text-4xl md:text-5xl">상품 관리</h1>
@@ -102,6 +107,7 @@ export default function Page() {
             ))}
           </tbody>
         </table>
+        {openNew && <NewProductModal />}
       </div>
     </div>
   );


### PR DESCRIPTION
# PR 템플릿 양식

## 변경 사항

- 상품 추가 모달 수정
- 상품 수정 모달 수정
- 카테고리 추가 모달 수정

## 작업 내용
- 상품 추가 모달 및 카테고리 추가 모달을 URL을 통해 접근 하거나 새로고침 시 기존 처럼 `page.tsx` 위에 모달 창을 오버레이 하는 방식
- 상품 수정 할 시에는 새로고침 할 시 pos/products로 이동

### 배경

- 모달 창을 켜 놓은 상태에서 새로고침 및 URL을 통한 직접 접근 시 `<div>page</div>` 같은 화면이 보이는 현상이 발견 되어 수정하게 되었습니다.

### 주요 변경 사항 및 스크린샷

<img width="1678" height="905" alt="스크린샷 2025-10-01 13 39 39" src="https://github.com/user-attachments/assets/19f2167f-c65b-4991-a501-facfe2fee94f" />

- 위 사진 처럼 모달을 단독으로 page.tsx에 쓰려고 하니 UI적으로 부자연스럽다고 생각하여 새로고침 하면 `pos/products` 로 돌아가며 모달창을 닫을 것인지 모달창을 유지할 것 인지에 고민하다가 모달창을 유지하는 쪽으로 정했습니다.

### 테스트

- window.history 있는 상황과 없는 상황에서 URL 접근 테스트 완료
- URL로 접근한 뒤 새로고침 테스트 완료
- 정상적인 루트로 클릭해서 새로고침 테스트 완료

## 참고사항

- 상품 수정 같은 경우에는 SearchParams로 넘기는 과정에서 복잡하고 무거워진다고 생각하여 `pos/products`로 돌아가는 방법을 채택하였습니다.

## 체크리스트

- [x] 코드가 의도한 대로 동작하는지 확인함
- [x] 테스트를 추가/수정함
- [x] 관련 문서/코멘트를 수정함
- [x] 셀프 리뷰 완료
