### PR TITLE
feat: 주문 내역 확인 모달 페이지 구현 및 결제 금액 로직 개선

### DIFF
--- a/src/app/(private)/pos/tables/[tableId]/@modal/(.)orders/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/@modal/(.)orders/page.tsx
@@ -11,40 +11,44 @@ export default function OrderCheckModal() {
 
   const orderId = orderIdParam ? Number(orderIdParam) : undefined;
 
-  const { data, isFetching, isError } = useOrder(orderId);
-
-  if (isFetching) return <div className="p-2 text-sm text-gray-400">로딩…</div>;
-  if (isError || !data)
-    return <div className="p-2 text-sm text-red-500">불러오기 실패</div>;
+  const { data } = useOrder(orderId);
 
   return (
     <ModalShell title={'주문 내역'} size="default">
       <div className="flex flex-col w-[21rem] max-w-full">
-        {/* 주문 리스트 (스크롤 영역) */}
-        <div className="max-h-[250px] overflow-y-auto scrollbar-hide">
-          {data?.orderItems?.map((item) => (
-            <div
-              key={item.orderItemId}
-              className="flex items-center justify-between py-3"
-            >
-              <span>
-                {item.menuName} × {item.quantity}
-              </span>
-              <span className="text-gray-500">
-                {item.itemPrice.toLocaleString()}원
-              </span>
-            </div>
-          ))}
-        </div>
-
-        {/* 합계 + 버튼 (고정 영역) */}
-        <div className="mt-4 border-t pt-4 space-y-4">
-          <div className="flex items-center justify-between text-lg font-semibold">
-            <span>총 결제 금액</span>
-            <span>{data?.totalPrice.toLocaleString()}원</span>
+        {!orderId || !data ? (
+          <div className="flex items-center justify-center py-8 text-gray-500">
+            주문 내역이 없습니다.
           </div>
-          <Button className="w-full h-12">결제하기</Button>
-        </div>
+        ) : (
+          <>
+            {/* 주문 리스트 (스크롤 영역) */}
+            <div className="max-h-[250px] overflow-y-auto scrollbar-hide">
+              {data?.orderItems?.map((item) => (
+                <div
+                  key={item.orderItemId}
+                  className="flex items-center justify-between py-3"
+                >
+                  <span>
+                    {item.menuName} × {item.quantity}
+                  </span>
+                  <span className="text-gray-500">
+                    {item.itemPrice.toLocaleString()}원
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            {/* 합계 + 버튼 (고정 영역) */}
+            <div className="mt-4 border-t pt-4 space-y-4">
+              <div className="flex items-center justify-between text-lg font-semibold">
+                <span>총 결제 금액</span>
+                <span>{data?.totalPrice.toLocaleString()}원</span>
+              </div>
+              <Button className="w-full h-12">결제하기</Button>
+            </div>
+          </>
+        )}
       </div>
     </ModalShell>
   );

--- a/src/app/(private)/pos/tables/[tableId]/@modal/(.)orders/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/@modal/(.)orders/page.tsx
@@ -2,41 +2,36 @@
 
 import ModalShell from '@/components/ModalShell';
 import { Button } from '@/components/ui/button';
-
-// 임시 주문 데이터
-const ORDER_ITEMS = [
-  { id: 1, name: '돈까스', quantity: 1, price: 13000 },
-  { id: 2, name: '돈까스', quantity: 2, price: 13000 },
-  { id: 3, name: '돈까스', quantity: 1, price: 13000 },
-  { id: 4, name: '돈까스', quantity: 3, price: 13000 },
-  { id: 5, name: '돈까스', quantity: 1, price: 13000 },
-  { id: 6, name: '돈까스', quantity: 1, price: 13000 },
-  { id: 7, name: '돈까스', quantity: 1, price: 13000 },
-  { id: 8, name: '돈까스', quantity: 1, price: 13000 },
-  { id: 9, name: '돈까스', quantity: 1, price: 13000 },
-];
+import { useOrder } from '@/hooks/useOrder';
+import { useSearchParams } from 'next/navigation';
 
 export default function OrderCheckModal() {
-  const total = ORDER_ITEMS.reduce(
-    (sum, item) => sum + item.price * item.quantity,
-    0,
-  );
+  const param = useSearchParams();
+  const orderIdParam = param.get('orderId');
+
+  const orderId = orderIdParam ? Number(orderIdParam) : undefined;
+
+  const { data, isFetching, isError } = useOrder(orderId);
+
+  if (isFetching) return <div className="p-2 text-sm text-gray-400">로딩…</div>;
+  if (isError || !data)
+    return <div className="p-2 text-sm text-red-500">불러오기 실패</div>;
 
   return (
     <ModalShell title={'주문 내역'} size="default">
       <div className="flex flex-col w-[21rem] max-w-full">
         {/* 주문 리스트 (스크롤 영역) */}
         <div className="max-h-[250px] overflow-y-auto scrollbar-hide">
-          {ORDER_ITEMS.map((item) => (
+          {data?.orderItems?.map((item) => (
             <div
-              key={item.id}
+              key={item.orderItemId}
               className="flex items-center justify-between py-3"
             >
               <span>
-                {item.name} × {item.quantity}
+                {item.menuName} × {item.quantity}
               </span>
               <span className="text-gray-500">
-                {(item.price * item.quantity).toLocaleString()}원
+                {item.itemPrice.toLocaleString()}원
               </span>
             </div>
           ))}
@@ -46,7 +41,7 @@ export default function OrderCheckModal() {
         <div className="mt-4 border-t pt-4 space-y-4">
           <div className="flex items-center justify-between text-lg font-semibold">
             <span>총 결제 금액</span>
-            <span>{total.toLocaleString()}원</span>
+            <span>{data?.totalPrice.toLocaleString()}원</span>
           </div>
           <Button className="w-full h-12">결제하기</Button>
         </div>

--- a/src/app/(private)/pos/tables/[tableId]/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/page.tsx
@@ -73,8 +73,6 @@ export default function PosMenuPage() {
     isError: orderIsError,
   } = useOrder(orderId);
 
-  console.log(order);
-
   // 주문 생성 / 재주문
   const createOrder = useCreateOrder(Number(tableId));
   const addOrder = useAddOrder(Number(orderId));
@@ -304,9 +302,12 @@ export default function PosMenuPage() {
           </Button>
 
           <Button asChild className="w-full bg-slate-600 h-12">
-            <Link href={`/pos/tables/${tableId}/orders`}>
+            <Link href={`/pos/tables/${tableId}/orders?orderId=${orderId}`}>
               <span className="font-semibold">
-                {cart.totalPrice.toLocaleString()}원 결제
+                {order?.totalPrice
+                  ? (order?.totalPrice + cart.totalPrice).toLocaleString()
+                  : cart.totalPrice.toLocaleString()}
+                원 결제
               </span>
             </Link>
           </Button>

--- a/src/hooks/useOrder.ts
+++ b/src/hooks/useOrder.ts
@@ -17,6 +17,7 @@ export function useOrder(orderId?: number) {
     queryKey: ['order', orderId],
     queryFn: () => getOrder(orderId as number),
     staleTime: 60 * 5 * 1000,
+    enabled: !!orderId,
   });
 }
 


### PR DESCRIPTION

# 주문 내역 확인 모달 구현 및 결제 금액 로직 개선

## 변경 사항
* 주문 내역 확인 모달 페이지에 `GET /api/stores/{storeId}/orders/{orderId}` API 연동
* 포스 메뉴 페이지에서 결제 금액 계산 로직 개선
  * 기존: 카트 금액만 or 기존 주문 금액만 단독 표시
  * 변경: 기존 주문 금액 + 카트 금액 합산 표시 (기존 주문 내역이 없으면 카트 금액만 표시)
* `useOrder` 훅 로직 개선 → `orderId`가 있을 때만 쿼리 실행하도록 옵션 추가

<br/>

## 작업 내용

### 배경
* 주문 내역 확인 모달 페이지에서 주문 내역 확인 기능 개발
* 사용자의 직관에 맞게 기존 주문 내역 + 새로 담은 카트 내역 = 최종 결제 금액 구조로 변경

<br/>

### 주요 변경 사항

**1. useOrder 훅 수정**
   * `orderId`가 존재할 때만 쿼리 실행되도록 조건 추가
   * API 호출 불필요 시 낭비되는 네트워크 요청 방지
   ```tsx
   return useQuery<OrderResponse[]>({
     queryKey: ['order', orderId],
     queryFn: () => getOrder(orderId),
     enabled: !!orderId, 
   });
   ```

<br/>

**2. 포스 메뉴 페이지 결제 금액 로직 개선**
  * 기존: 카트 금액만 or 기존 주문 금액만 단독 표시
  * 변경: 기존 주문 금액 + 카트 금액 합산 표시 (기존 주문 내역이 없으면 카트 금액만 표시)
    <img width="600" alt="포스 메뉴 - 결제 가격에 주문 내역 + 카드 금액" src="https://github.com/user-attachments/assets/299adfab-d370-4f22-986f-4a19bbe513d5" />

<br/>

**3. 주문 내역 확인 모달 페이지 구현**
   * `GET /api/stores/{storeId}/orders/{orderId}` API로 주문 내역 리스트 + 합계 금액 표시
     <img width="600" alt="주문 내역 확인" src="https://github.com/user-attachments/assets/06eebf25-aa1e-4dac-a050-a23a504bb17d" />
   * `orderId`가 없는 경우 → “주문 내역이 없습니다.” 텍스트 출력
     <img width="600" alt="주문 내역 확인 - 주문 내역 없을 때" src="https://github.com/user-attachments/assets/d7ee86b1-aa0c-4130-ae5f-223d7956c5aa" />

<br/>

### 테스트
* 주문 내역 확인 페이지
   * [x] `orderId`가 정상적으로 있는 경우 → 주문 내역 정상 표시 확인
   * [x] `orderId`가 `undefined`인 경우 → “주문 내역이 없습니다.” 메시지 출력 확인
* 포스 메뉴 페이지
   * [x] 기존 주문 내역이 있는 경우 → 기존 주문 금액 + 카트 금액 합산 확인
   * [x] 기존 주문 내역이 없는 경우 → 카트 금액만 표시 확인
* [x] 로컬에서 정상 동작 확인 완료

<br/>

## 체크리스트
* [x] 코드가 의도한 대로 동작하는지 확인함
* [ ] 테스트를 추가/수정함
* [x] 관련 문서/코멘트를 수정함
* [x] 셀프 리뷰 완료


