### PR TITLE
fix: 메뉴별 총 가격 표시 및 주문 생성 오류 수정

### DIFF
--- a/src/app/(private)/pos/tables/[tableId]/@modal/(.)orders/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/@modal/(.)orders/page.tsx
@@ -33,7 +33,7 @@ export default function OrderCheckModal() {
                     {item.menuName} × {item.quantity}
                   </span>
                   <span className="text-gray-500">
-                    {item.itemPrice.toLocaleString()}원
+                    {item.totalItemPrice.toLocaleString()}원
                   </span>
                 </div>
               ))}

--- a/src/app/(private)/pos/tables/[tableId]/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/page.tsx
@@ -74,12 +74,13 @@ export default function PosMenuPage() {
   } = useOrder(orderId);
 
   // 주문 생성 / 재주문
+  const tableNumberParam = param.get('no');
+  const tableNumber = Number(tableNumberParam);
+
   const createOrder = useCreateOrder(Number(tableId));
   const addOrder = useAddOrder(Number(orderId));
 
   function handleOrderClick() {
-    const tableNumber = Number(tableId);
-
     if (!tableNumber || Number.isNaN(tableNumber)) return;
     if (cart.cartItems.length === 0) return;
 
@@ -173,7 +174,9 @@ export default function PosMenuPage() {
         <div className="p-[18px] border-b flex-shrink-0">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-2">
-              <span className="text-lg font-semibold">{tableId}번 테이블</span>
+              <span className="text-lg font-semibold">
+                {tableNumber}번 테이블
+              </span>
               <span
                 className={`text-xs px-2 py-1 rounded ${
                   STATUS_COLORS[order?.status as keyof typeof STATUS_COLORS]

--- a/src/app/api/order.ts
+++ b/src/app/api/order.ts
@@ -18,6 +18,7 @@ export type OrderResponse = {
     menuName: string;
     quantity: number;
     itemPrice: number;
+    totalItemPrice: number;
   }[];
   paid: boolean;
 };

--- a/src/components/ExistingOrderList.tsx
+++ b/src/components/ExistingOrderList.tsx
@@ -18,7 +18,7 @@ export default function ExistingOrderList({
             {item.menuName} x {item.quantity}
           </p>
           <span className=" text-gray-500 select-none">
-            {item.itemPrice.toLocaleString()}
+            {item.totalItemPrice.toLocaleString()}
           </span>
         </div>
       ))}

--- a/src/hooks/useTables.ts
+++ b/src/hooks/useTables.ts
@@ -35,8 +35,8 @@ export function useTables(page: number) {
     query.data?.content.map((item) => {
       const status = toUIStatus(item.displayStatus);
       const href = item.activeOrder?.orderId
-        ? `/pos/tables/${item.restaurantTableNumber}?orderId=${item.activeOrder.orderId}`
-        : `/pos/tables/${item.restaurantTableNumber}`;
+        ? `/pos/tables/${item.id}?orderId=${item.activeOrder.orderId}&no=${item.restaurantTableNumber}`
+        : `/pos/tables/${item.id}?no=${item.restaurantTableNumber}`;
 
       return {
         tableNumber: item.restaurantTableNumber,


### PR DESCRIPTION

# 메뉴별 총 가격 표시 및 주문 생성 오류 수정

## 변경 사항
* 기존 주문 내역/주문 내역 모달에서 **메뉴 별 총 가격 표시 로직 수정**
* 주문 생성 불가 문제 해결
  * 테이블 라우팅 시 `restaurantTableNumber` 대신 **id 기반 이동**으로 수정
  * `restaurantTableNumber`는 query 파라미터로 전달하도록 변경

<br/>

## 작업 내용

### 배경
* 기존에는 총 가격 대신 단가 * 수량으로 계산하거나, 아예 합산되지 않은 값이 표시되는 문제가 있었음
   * 백엔드 API에서 메뉴 항목에 단일 가격뿐 아니라 총 가격(`totalItemPrice`)이 내려오도록 변경됨
* 주문 생성 시 path에 `restaurantTableNumber`를 그대로 넘겨서 서버가 해당 id를 찾지 못하는 문제 발생

<br/>

### 주요 변경 사항
**1. 메뉴 별 총 가격 표시**
  * 백엔드에서 추가한 총 가격(`totalItemPrice`)를 기존 메뉴 별 총 가격이 필요한 부분에 교체
     * 메뉴 항목에 포스 메뉴 페이지 오른쪽 영역의 기존 주문 내역
     * 주문 내역 확인 모달의 각 메뉴

<br/>

**2. 주문 생성 불가 문제 해결**
  * **기존**: 테이블 페이지 → 테이블 카드 클릭 후 이동 시 path에 restaurantTableNumber로 이동하도록 함 
  * **에러**: 서버는 path에서 id(PK)를 기대해서 주문 생성 시 "Table ID does not exist" 에러 발생
  * **해결**: 테이블 카드 이동 path에 id를 사용하도록 변경, restaurantTableNumber는 query 파라미터(`?no=`)로 별도로 전달 후 사용

<br/>

### 테스트
* 로컬에서 신규 API 응답(`totalItemPrice`) 기반으로 기존 주문 내역/모달 총 가격이 정상 표시되는지 확인
* id 기반 라우팅 후 주문 생성이 정상적으로 동작하는지 확인

<br/>

## 체크리스트
* [x] 코드가 의도한 대로 동작하는지 확인함
* [x] 테스트를 추가/수정함 (로컬 확인)
* [x] 관련 문서/코멘트를 수정함
* [x] 셀프 리뷰 완료

