### PR TITLE
refactor: /pos 경로 뒤로가기 동작 및 Header 매장명 표시 문제 해결

### DIFF
--- a/src/app/(private)/pos/(shell-layout)/layout.tsx
+++ b/src/app/(private)/pos/(shell-layout)/layout.tsx
@@ -4,7 +4,7 @@ import Header from '@/components/Header';
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (
     <div className="bg-default flex flex-col min-h-screen">
-      <Header storeName={'/'} />
+      <Header />
 
       <main className="w-[80%]  mx-auto  pt-8  flex-1 overflow-auto scrollbar-hide">
         <BackButton buttonStyle={'w-14'} iconStyle={'size-5'} />

--- a/src/app/(private)/pos/tables/[tableId]/layout.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/layout.tsx
@@ -10,7 +10,7 @@ export default function PosMenuLayout({
   return (
     <>
       <div className="bg-default flex flex-col min-h-screen">
-        <Header storeName={'/'} />
+        <Header />
         <main>{children}</main>
         {modal}
       </div>

--- a/src/app/api/login.ts
+++ b/src/app/api/login.ts
@@ -19,6 +19,7 @@ export async function postLogin(
 
   if (data.stores?.length > 0) {
     localStorage.setItem('storeId', String(data.stores[0].storeId));
+    localStorage.setItem('storeName', String(data.stores[0].storeName));
   }
 
   return data;

--- a/src/components/BackButton.tsx
+++ b/src/components/BackButton.tsx
@@ -23,6 +23,11 @@ export default function BackButton({
       return;
     }
 
+    if (currentPath === '/pos') {
+      router.push('/');
+      return;
+    }
+
     const pathSegments = currentPath.split('/'); // ['', 'pos', 'tables']
     const parentSegments = pathSegments.slice(0, -1); // ['', 'pos']
     const parentPath = parentSegments.join('/'); // /pos

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,12 +1,21 @@
+'use client';
+
 import Link from 'next/link';
 import Logo from './Logo';
 import LiveTime from './LiveTime';
+import { useEffect, useState } from 'react';
 
-interface HeaderProps {
-  storeName: string;
-}
+export default function Header() {
+  const [storeName, setStoreName] = useState('');
 
-export default function Header({ storeName = '매장명' }: HeaderProps) {
+  useEffect(() => {
+    const name = localStorage.getItem('storeName');
+
+    if (name) {
+      setStoreName(name);
+    }
+  }, []);
+
   return (
     <header className="h-20 bg-header text-white">
       <div className="mx-auto  h-full flex items-center justify-between px-16">


### PR DESCRIPTION

# /pos 경로 뒤로가기 동작 및 Header 매장명 표시 문제 해결

## 변경 사항
* `/pos` 경로에서 뒤로가기 시 루트(`/`)로 이동하도록 조건 추가
* 로그인 시 반환되는 `storeName`을 `localStorage`에 저장 후 Header에서 매장명 표시

<br/>

## 작업 내용

### 배경
* 기존에는 `/pos` 경로에서 뒤로가기 버튼을 눌러도 상위 페이지로 이동하지 않아 UX가 불편 → 개선 필요
* 로그인 후 매장명(`storeName`)이 Header에 표시되지 않는 문제가 발생함
  → 로그인 시 반환된 `storeName`을 저장하고, Header에서 해당 값을 읽어오도록 로직 추가

<br/>

### 주요 변경 사항 및 스크린샷

**1. `/pos` 경로에서 뒤로가기 시 루트(`/`)로 이동하도록 수정**
   * 기존: 다른 경로에선 뒤로가기 시 상위 페이지로 이동하지만, `/pos` 경로에선 뒤로가기 시 이동되지 않음
   * 개선: `/pos` 경로에서 뒤로가기 시 랜딩 및 로그인 페이지로 이동하도록 조건문 추가

<br/>

**2. `Header`에 매장명이 안 들어오는 문제**
   * 로그인 시 응답으로 받은 `storeName`을 `localStorage`에 저장하도록 함
   * Header 컴포넌트에서 `localStorage.getItem('storeName')`으로 값을 가져와 표시
   * `Header`의 props 제거 → 클라이언트 컴포넌트로 전환

<br/>

### 테스트
* 로컬 환경에서 로그인 후 Header에 매장명이 정상 표시되는지 확인
* `/pos` 진입 후 뒤로가기 시 루트(`/`)로 이동하는지 확인

<br/>

## 체크리스트
* [x] 코드가 의도한 대로 동작하는지 확인함
* [ ] 테스트를 추가/수정함
* [x] 관련 문서/코멘트를 수정함
* [x] 셀프 리뷰 완료
