### PR TITLE
feat: 토스페이먼츠 결제 기능 구현 - 결제창 연동 및 승인 API 연결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-slot": "^1.2.3",
         "@tanstack/react-query": "^5.87.4",
         "@tanstack/react-query-devtools": "^5.90.2",
+        "@tosspayments/tosspayments-sdk": "^2.4.0",
         "axios": "^1.12.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1969,7 +1970,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.2.tgz",
       "integrity": "sha512-CLABiR+h5PYfOWr/z+vWFt5VsOA2ekQeRQBFSKlcoW6Ndx/f8rfyVmq4LbgOM4GG2qtxAxjLYLOpCNTYm4uKzw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.2"
       },
@@ -1997,6 +1997,12 @@
         "@tanstack/react-query": "^5.90.2",
         "react": "^18 || ^19"
       }
+    },
+    "node_modules/@tosspayments/tosspayments-sdk": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@tosspayments/tosspayments-sdk/-/tosspayments-sdk-2.4.0.tgz",
+      "integrity": "sha512-Ljs9QCl45+mehyykPcWN2kh562Uo5a4kQIqentKvdv+YQ+yz6L2F2Kgph1vJcoQKk8vZKHckBezlmFW6MGl8Ww==",
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
@@ -2046,7 +2052,6 @@
       "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -2057,7 +2062,6 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2108,7 +2112,6 @@
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
         "@typescript-eslint/types": "8.44.0",
@@ -2626,7 +2629,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3573,7 +3575,6 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3748,7 +3749,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5971,7 +5971,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5981,7 +5980,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -6775,7 +6773,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6935,7 +6932,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-slot": "^1.2.3",
     "@tanstack/react-query": "^5.87.4",
     "@tanstack/react-query-devtools": "^5.90.2",
+    "@tosspayments/tosspayments-sdk": "^2.4.0",
     "axios": "^1.12.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/app/(private)/pos/(shell-layout)/payment/fail/route.ts
+++ b/src/app/(private)/pos/(shell-layout)/payment/fail/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+
+  // 토스페이먼츠 실패 정보
+  const errorCode = searchParams.get('code');
+  const errorMessage = searchParams.get('message');
+  const orderId = searchParams.get('orderId');
+
+  // 리다이렉트 tableId
+  const tableId = searchParams.get('tableId');
+
+  const targetPage = `/pos/tables/${tableId}/orders`;
+
+  const targetSearchParams = new URLSearchParams({
+    orderId: orderId || '',
+
+    paymentFailed: 'true',
+    code: errorCode || 'UNKNOWN_ERROR',
+    message: errorMessage || '결제 중 알 수 없는 오류 발생',
+  });
+
+  const redirectUrl = new URL(
+    `${targetPage}?${targetSearchParams}`,
+    request.url,
+  );
+
+  return NextResponse.redirect(redirectUrl);
+}

--- a/src/app/(private)/pos/(shell-layout)/payment/fail/route.ts
+++ b/src/app/(private)/pos/(shell-layout)/payment/fail/route.ts
@@ -11,6 +11,7 @@ export async function GET(request: Request) {
   // 리다이렉트 tableId
   const tableId = searchParams.get('tableId');
 
+  // 리다이렉트 페이지 경로
   const targetPage = `/pos/tables/${tableId}/orders`;
 
   const targetSearchParams = new URLSearchParams({
@@ -18,7 +19,7 @@ export async function GET(request: Request) {
 
     paymentFailed: 'true',
     code: errorCode || 'UNKNOWN_ERROR',
-    message: errorMessage || '결제 중 알 수 없는 오류 발생',
+    message: errorMessage || '결제 중 오류 발생',
   });
 
   const redirectUrl = new URL(

--- a/src/app/(private)/pos/(shell-layout)/payment/success/page.tsx
+++ b/src/app/(private)/pos/(shell-layout)/payment/success/page.tsx
@@ -1,35 +1,78 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Check, CreditCard, Clock, FileText } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
-
-// 토스 결제 응답 타입 정의
-interface PaymentData {
-  totalAmount: number;
-  method: string;
-  approvedAt: string;
-  approveNo: string;
-  cardNumber?: string;
-  company?: string;
-}
-
-// 예시 데이터
-const paymentData: PaymentData = {
-  totalAmount: 25000,
-  method: '카드',
-  approvedAt: '2025-09-19 14:10:25',
-  approveNo: '12345678',
-  cardNumber: '433012******1234',
-  company: '현대카드',
-};
+import { useSearchParams } from 'next/navigation';
+import { useConfirmPayment } from '@/hooks/usePayment';
+import type { PaymentResponse as TossPaymentResponse } from '@/app/api/payments';
 
 export default function PaymentSuccessPage() {
+  const params = useSearchParams();
+
+  const orderId = params.get('orderId');
+  const paymentKey = params.get('paymentKey');
+
+  const amtStr = params.get('amount');
+  const amount = amtStr ? parseInt(amtStr, 10) : undefined;
+
+  const { mutateAsync, isError } = useConfirmPayment();
+
+  const [paymentLocal, setPaymentLocal] = useState<TossPaymentResponse | null>(
+    null,
+  );
+
+  const calledRef = useRef(false);
+
+  useEffect(() => {
+    const ready = !!(paymentKey && orderId && amount != null);
+    console.log('[PAY] params ready:', { paymentKey, orderId, amount, ready });
+
+    if (calledRef.current || !ready) return;
+    calledRef.current = true;
+
+    (async () => {
+      try {
+        const res = await mutateAsync({
+          paymentKey,
+          orderId,
+          amount: amount as number,
+        });
+
+        setPaymentLocal(res);
+
+        console.log('토스페이먼츠 결제 승인 성공:', res);
+      } catch (err) {
+        console.error('토스페이먼츠 결제 승인 실패:', err);
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paymentKey, orderId, amount]);
+
+  if (!paymentLocal && !isError) {
+    return <div className="p-10">결제 정보를 확인 중입니다…</div>;
+  }
+
+  if (isError || !paymentLocal) {
+    return (
+      <div className="flex flex-col items-center justify-center p-10 text-red-600">
+        <h2 className="text-xl font-bold mb-2">결제 확인에 실패했습니다.</h2>
+        <p>다시 시도해 주세요.</p>
+        <Link href="/pos/tables">
+          <Button className="mt-4 bg-red-600 hover:bg-red-700">
+            테이블 페이지로 돌아가기
+          </Button>
+        </Link>
+      </div>
+    );
+  }
+
+  const payment = paymentLocal;
+
   return (
     <div className="flex flex-col items-center justify-center ">
-      {/* 성공 아이콘 & 메시지 */}
       <div className="text-center mb-5">
         <div className="w-13 h-13 bg-green-500 rounded-full flex items-center justify-center mx-auto mb-3 animate-pulse">
           <Check size={32} className="text-white" />
@@ -55,7 +98,7 @@ export default function PaymentSuccessPage() {
           <div className="flex justify-between items-center py-2 border-b border-gray-100">
             <span className="text-gray-600 text-sm">결제 금액</span>
             <span className="text-lg font-bold text-blue-600">
-              {paymentData.totalAmount.toLocaleString()}원
+              {(amount as number).toLocaleString()}원
             </span>
           </div>
 
@@ -66,10 +109,10 @@ export default function PaymentSuccessPage() {
               결제 방법
             </span>
             <div className="text-right">
-              <div className="font-medium text-sm">{paymentData.method}</div>
-              {paymentData.company && paymentData.cardNumber && (
+              <div className="font-medium text-sm">{payment.method}</div>
+              {payment.cardCompany && payment.maskedCardNumber && (
                 <div className="text-xs text-gray-500">
-                  {paymentData.company} ({paymentData.cardNumber})
+                  {payment.cardCompany} ({payment.maskedCardNumber})
                 </div>
               )}
             </div>
@@ -81,27 +124,23 @@ export default function PaymentSuccessPage() {
               <Clock size={14} />
               결제 시간
             </span>
-            <span className="font-medium text-sm">
-              {paymentData.approvedAt}
-            </span>
+            <span className="font-medium text-sm">{payment.approvedAt}</span>
           </div>
 
           {/* 승인번호 */}
           <div className="flex justify-between items-center py-2 bg-gray-50 px-3 rounded-lg">
             <span className="text-gray-600 text-sm">승인번호</span>
             <span className="font-mono text-xs font-medium">
-              {paymentData.approveNo}
+              {payment.approvalNumber}
             </span>
           </div>
         </CardContent>
       </Card>
 
-      {/* CTA 버튼 */}
       <Button className="w-full max-w-sm">
         <Link href={'/pos/tables'}>테이블 페이지로 돌아가기</Link>
       </Button>
 
-      {/* 추가 안내 */}
       <p className="text-xs text-gray-500 mt-4 text-center max-w-sm">
         영수증이 필요하신 경우 승인번호를 이용해 출력하실 수 있습니다.
       </p>

--- a/src/app/(private)/pos/tables/[tableId]/page.tsx
+++ b/src/app/(private)/pos/tables/[tableId]/page.tsx
@@ -43,6 +43,7 @@ export default function PosMenuPage() {
   const pathname = usePathname();
   const params = useSearchParams();
 
+  // 에러 토스트 중복 방지 플래그
   const shownRef = useRef(false);
 
   const paymentFailed = params.get('paymentFailed');
@@ -50,11 +51,14 @@ export default function PosMenuPage() {
   const errorMessage = params.get('message');
 
   useEffect(() => {
+    // 1. 이미 알림을 띄웠거나, 실패 파라미터가 없으면 즉시 종료
     if (shownRef.current) return;
     if (paymentFailed !== 'true') return;
 
+    // 2. 에러 토스트 플래그 설정(중복 방지)
     shownRef.current = true;
 
+    // 3. 에러 토스트 띄우기
     toast.error(
       `[결제 실패] 코드: ${errorCode ?? 'UNKNOWN_ERROR'}, 메시지: ${
         errorMessage ?? '결제 중 오류가 발생했어요.'
@@ -67,11 +71,13 @@ export default function PosMenuPage() {
       }`,
     );
 
+    // 4. URL 쿼리 파라미터 정리 - replace를 위해 실패 관련 키 삭제
     const newParams = new URLSearchParams(params.toString());
     newParams.delete('paymentFailed');
     newParams.delete('code');
     newParams.delete('message');
 
+    // 5. replace로 페이지 이동 없이 URL만 교체
     router.replace(`${pathname}?${newParams.toString()}`);
   }, [paymentFailed, errorCode, errorMessage, router, pathname, params]);
 

--- a/src/app/api/payments.ts
+++ b/src/app/api/payments.ts
@@ -1,0 +1,24 @@
+import { instance } from '@/lib/axios';
+
+export type PaymentConfirmRequest = {
+  paymentKey: string;
+  orderId: string;
+  amount: number;
+};
+
+export type PaymentResponse = {
+  orderId: string;
+  method: string;
+  cardCompany: string;
+  maskedCardNumber: string;
+  approvalNumber: string;
+  approvedAt: string;
+};
+
+export async function confirmPayment(body: PaymentConfirmRequest) {
+  const { data } = await instance.post<PaymentResponse>(
+    '/payments/confirm',
+    body,
+  );
+  return data;
+}

--- a/src/components/page/OrderCheck.tsx
+++ b/src/components/page/OrderCheck.tsx
@@ -79,7 +79,7 @@ export default function OrderCheck() {
       orderId: pgOrderId, // 결제용 orderId
       orderName: orderName,
       successUrl: `${origin}/pos/payment/success`,
-      failUrl: `${origin}/api/payment/fail?tableId=${tableId}&orderId=${orderIdParam}`,
+      failUrl: `${origin}/pos/payment/fail?tableId=${tableId}&orderId=${orderIdParam}`,
     });
   };
 

--- a/src/components/page/OrderCheck.tsx
+++ b/src/components/page/OrderCheck.tsx
@@ -11,7 +11,11 @@ import { useEffect, useState } from 'react';
 
 const clientKey = process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY!;
 
-const origin = window.location.origin;
+// 임시 orderID 생성 함수
+const makePgOrderId = (base: number | string) =>
+  `SN-${base}-${Date.now().toString(36)}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
 
 export default function OrderCheck() {
   // 주문 내역
@@ -63,13 +67,16 @@ export default function OrderCheck() {
 
     console.log(orderName); // 콤비네이션 피자 외 3건
 
+    const pgOrderId = makePgOrderId(orderId);
+    const origin = window.location.origin;
+
     await paymentInstance.requestPayment({
       method: 'CARD',
       amount: {
         currency: 'KRW',
         value: data.totalPrice,
       },
-      orderId: 'ord_25mb3kz5_ab12cd', // 결제용 orderId
+      orderId: pgOrderId, // 결제용 orderId
       orderName: orderName,
       successUrl: `${origin}/pos/payment/success`,
       failUrl: `${origin}/api/payment/fail?tableId=${tableId}&orderId=${orderIdParam}`,

--- a/src/components/page/OrderCheck.tsx
+++ b/src/components/page/OrderCheck.tsx
@@ -16,13 +16,13 @@ const origin = window.location.origin;
 export default function OrderCheck() {
   // 주문 내역
   const param = useSearchParams();
-  const orderIdParam = param.get('orderId');
 
+  const orderIdParam = param.get('orderId');
   const orderId = orderIdParam ? Number(orderIdParam) : undefined;
 
   const { data } = useOrder(orderId);
 
-  console.log(data);
+  const tableId = data?.restaurantTableId;
 
   // 토스페이먼츠 결제 api
   const [paymentInstance, setPaymentInstance] =
@@ -69,10 +69,10 @@ export default function OrderCheck() {
         currency: 'KRW',
         value: data.totalPrice,
       },
-      orderId: 'ord_25mb3kz5_ab12cd', // 결제용 orderId 필요(영문 대소문자, 숫자, 특수문자(-, _) 만 허용,6자 ~ 64자)
+      orderId: 'ord_25mb3kz5_ab12cd', // 결제용 orderId
       orderName: orderName,
       successUrl: `${origin}/pos/payment/success`,
-      failUrl: `${origin}/pos/payment/fail`,
+      failUrl: `${origin}/api/payment/fail?tableId=${tableId}&orderId=${orderIdParam}`,
     });
   };
 

--- a/src/components/page/OrderCheck.tsx
+++ b/src/components/page/OrderCheck.tsx
@@ -1,16 +1,80 @@
 'use client';
 
+import {
+  loadTossPayments,
+  TossPaymentsPayment,
+} from '@tosspayments/tosspayments-sdk';
 import { useOrder } from '@/hooks/useOrder';
 import { useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
+import { useEffect, useState } from 'react';
+
+const clientKey = process.env.NEXT_PUBLIC_TOSS_CLIENT_KEY!;
+
+const origin = window.location.origin;
 
 export default function OrderCheck() {
+  // 주문 내역
   const param = useSearchParams();
   const orderIdParam = param.get('orderId');
 
   const orderId = orderIdParam ? Number(orderIdParam) : undefined;
 
   const { data } = useOrder(orderId);
+
+  console.log(data);
+
+  // 토스페이먼츠 결제 api
+  const [paymentInstance, setPaymentInstance] =
+    useState<TossPaymentsPayment | null>(null);
+
+  useEffect(() => {
+    if (!clientKey || !data) return;
+
+    // 회원 식별 값
+    const customerKey = String(data?.id);
+
+    // SDK 초기화
+    const initializeTossPayments = async () => {
+      try {
+        const tossPayments = await loadTossPayments(clientKey);
+        const payment = tossPayments.payment({ customerKey: customerKey });
+
+        setPaymentInstance(payment);
+      } catch (error) {
+        console.error('토스 SDK 초기화 실패:', error);
+      }
+    };
+
+    initializeTossPayments();
+  }, [data]);
+
+  // 결제창 띄우기
+  const handlePayClick = async () => {
+    if (!orderId || !data || !paymentInstance) return;
+
+    // orderName 생성
+    const firstItemName = data.orderItems[0].menuName;
+    const otherItemsCount = data.orderItems.length - 1;
+    const orderName =
+      otherItemsCount > 0
+        ? `${firstItemName} 외 ${otherItemsCount}건`
+        : firstItemName;
+
+    console.log(orderName); // 콤비네이션 피자 외 3건
+
+    await paymentInstance.requestPayment({
+      method: 'CARD',
+      amount: {
+        currency: 'KRW',
+        value: data.totalPrice,
+      },
+      orderId: 'ord_25mb3kz5_ab12cd', // 결제용 orderId 필요(영문 대소문자, 숫자, 특수문자(-, _) 만 허용,6자 ~ 64자)
+      orderName: orderName,
+      successUrl: `${origin}/pos/payment/success`,
+      failUrl: `${origin}/pos/payment/fail`,
+    });
+  };
 
   return (
     <div className="flex flex-col w-[21rem] max-w-full">
@@ -43,7 +107,9 @@ export default function OrderCheck() {
               <span>총 결제 금액</span>
               <span>{data?.totalPrice.toLocaleString()}원</span>
             </div>
-            <Button className="w-full h-12">결제하기</Button>
+            <Button className="w-full h-12" onClick={handlePayClick}>
+              결제하기
+            </Button>
           </div>
         </>
       )}

--- a/src/hooks/usePayment.ts
+++ b/src/hooks/usePayment.ts
@@ -1,0 +1,25 @@
+import {
+  confirmPayment,
+  PaymentConfirmRequest,
+  PaymentResponse,
+} from '@/app/api/payments';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+export function useConfirmPayment() {
+  const queryClient = useQueryClient();
+
+  return useMutation<PaymentResponse, AxiosError, PaymentConfirmRequest>({
+    mutationKey: ['payments', 'confirm'],
+    mutationFn: confirmPayment,
+    onSuccess: (data) => {
+      console.log('결제 성공:', data);
+
+      queryClient.invalidateQueries({ queryKey: ['tables'] });
+    },
+    onError: (err) => {
+      console.error('status:', err?.response?.status);
+      console.error('data:', err?.response?.data);
+    },
+  });
+}


### PR DESCRIPTION

# 토스페이먼츠 결제 기능 구현 - 결제창 연동 및 승인 API 연결

## 변경 사항
* 토스페이먼츠 SDK 설치 및 초기 설정
* 결제 요청(`requestPayment`) 로직 추가
* 결제 성공/실패 플로우 구현
* 결제 승인 API(`POST /api/payments/confirm`) 연동
* 결제 실패 시 에러 토스트 표시 및 라우터 처리

<br/>

## 작업 내용

### 배경
* 포스 메뉴 페이지에서 주문 결제 기능을 실제 결제 모듈(토스페이먼츠)과 연동하기 위한 구현 작업

* 결제 테스트 환경에서 성공 & 실패 리다이렉트, API 연동, UI 반영을 일관되게 처리하기 위해 구조 정리

<br/>

### 주요 변경 사항

**1. SDK 설치 및 초기화**
  * `npm i @tosspayments/sdk` 설치
  * API 키 설정 및 SDK 초기화 코드 추가

<br/>

**2. 결제창 호출 로직 구현**
  * `requestPayment()` 호출 시 `amount`, `orderName`, `successUrl`, `failUrl` 등 옵션 전달
  * `tableId`, `orderId`를 URL 쿼리에 포함시켜 리다이렉트 시점에 주문 정보를 유지하도록 처리
  *  결제 중복 주문번호(`orderId`) 에러 발생 → 랜덤 문자열 생성 방식으로 임시 해결

<br/>

**3. 결제 성공 처리**
  * 결제 성공 시 `successUrl`로 리다이렉트되어 전달된 쿼리(`paymentKey`, `orderId`, `amount`)를 읽어옴
  * `POST /api/payments/confirm` API 호출로 결제 승인 요청
  * 승인 결과에 따라 결제 성공 페이지에서 실제 결제 정보 렌더링
    ![토스페이먼츠 결제(url X)](https://github.com/user-attachments/assets/270a5643-353a-4fac-a2f4-e9524cc4bf21)

<br/>

**4. 결제 실패 처리**
  * `failUrl` 전용 라우터(`payment/fail`) 추가
  * 실패 원인을 쿼리(`code`, `message`)로 받아 포스 메뉴 페이지에서 토스트 에러 메시지 출력
  * `tableId`를 함께 전달해 사용자가 원래 페이지로 자연스럽게 복귀 가능하도록 설계

<br/>

### 테스트
* 실제 결제 요청 및 성공/실패 플로우 로컬 환경에서 검증
* 결제 성공 시 백엔드 `/api/payments/confirm` 응답 정상 확인
* 중복 주문번호 오류 재현 후 랜덤 `orderId` 생성으로 재발 방지 확인

<br/>

## 체크리스트
* [x] 코드가 의도한 대로 동작하는지 확인함
* [x] 로컬 환경에서 성공/실패 플로우 테스트 
* [x] 관련 주석 및 타입 수정
* [x] 셀프 리뷰 완료
